### PR TITLE
Add optional name parameter to direct file url

### DIFF
--- a/src/embed/status.ts
+++ b/src/embed/status.ts
@@ -202,8 +202,8 @@ export const handleStatus = async (
     }
 
     if (redirectUrl) {
-      // TODO: only append name if it's an image
-      if (flags.name) {
+      // Only append name if it's an image
+      if (/\.(png|jpe?g|gif)(\?|$)/.test(redirectUrl) && flags.name) {
         redirectUrl = `${redirectUrl}:${flags.name}`;
       }
       return c.redirect(redirectUrl, 302);

--- a/src/embed/status.ts
+++ b/src/embed/status.ts
@@ -202,6 +202,10 @@ export const handleStatus = async (
     }
 
     if (redirectUrl) {
+      // TODO: only append name if it's an image
+      if (flags.name) {
+        redirectUrl = `${redirectUrl}:${flags.name}`;
+      }
       return c.redirect(redirectUrl, 302);
     }
   }

--- a/src/realms/twitter/routes/status.ts
+++ b/src/realms/twitter/routes/status.ts
@@ -82,7 +82,7 @@ export const statusRequest = async (c: Context) => {
       flags.name = nameFromSearchParams;
     } else {
       // check if the status ends with :<name>, e.g. /i/status/1234567890.jpg:orig
-      const matched = url.pathname.match(/\/status(?:es)?\/\d{2,20}(?:\..*?):(.*?)$/);
+      const matched = url.pathname.match(/\/status(?:es)?\/\d{2,20}(?:\..*?)?:(.+?)$/);
       const nameFromUrl = matched && matched[1];
       if (nameFromUrl) {
         flags.name = nameFromUrl;

--- a/src/realms/twitter/routes/status.ts
+++ b/src/realms/twitter/routes/status.ts
@@ -70,6 +70,26 @@ export const statusRequest = async (c: Context) => {
     flags.direct = true;
   }
 
+  /* Support redirecting to specific quality of image, like:
+  
+     https://pbs.twimg.com/media/foobar.jpg:orig
+    
+     TODO: Should we support video file like :1280x720, though it's not the offical way */
+  if (flags.direct) {
+    // check if the name is in search params, e.g. /i/status/1234567890?name=orig
+    const nameFromSearchParams = url.searchParams.get('name');
+    if (nameFromSearchParams) {
+      flags.name = nameFromSearchParams;
+    } else {
+      // check if the status ends with :<name>, e.g. /i/status/1234567890.jpg:orig
+      const matched = url.pathname.match(/\/status(?:es)?\/\d{2,20}(?:\..*?):(.*?)$/);
+      const nameFromUrl = matched && matched[1];
+      if (nameFromUrl) {
+        flags.name = nameFromUrl;
+      }
+    }
+  }
+
   /* TODO: Figure out what we're doing with FixTweet / FixupX branding in future */
   if (/fixup/g.test(url.href)) {
     console.log(`We're using x domain`);

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -12,6 +12,7 @@ type InputFlags = {
   archive?: boolean;
   gallery?: boolean;
   nativeMultiImage?: boolean;
+  name?: string;
 };
 
 interface StatusResponse {


### PR DESCRIPTION
Support redirecting to specific quality of image, like:

- `https://d.fixupx.com/i/status/1234567890` -> `https://pbs.twimg.com/media/foobarbaz.jpg`
- `https://d.fixupx.com/i/status/1234567890:orig` -> `https://pbs.twimg.com/media/foobarbaz.jpg:orig`
- `https://d.fixupx.com/i/status/1234567890?name=orig` -> `https://pbs.twimg.com/media/foobarbaz.jpg:orig`
- `https://fxtwitter.com/i/status/1234567890.jpg?name=orig` -> `https://pbs.twimg.com/media/foobarbaz.jpg:orig`

