### PR TITLE
Relax the name-in-url matching pattern

### DIFF
--- a/src/realms/twitter/routes/status.ts
+++ b/src/realms/twitter/routes/status.ts
@@ -82,7 +82,7 @@ export const statusRequest = async (c: Context) => {
       flags.name = nameFromSearchParams;
     } else {
       // check if the status ends with :<name>, e.g. /i/status/1234567890.jpg:orig
-      const matched = url.pathname.match(/\/status(?:es)?\/\d{2,20}(?:\..*?)?:(.+?)$/);
+      const matched = url.pathname.match(/\/status(?:es)?\/.+:([^:]+?)$/);
       const nameFromUrl = matched && matched[1];
       if (nameFromUrl) {
         flags.name = nameFromUrl;


### PR DESCRIPTION
This PR fixes a special case for #1116.

The original PR only matching the default status link, not the media link, so the media link would not have the `:<name>` suffix.

✔ https://d.fixupx.com/elonmusk/status/1884062175280668757?name=orig
✔ https://d.fixupx.com/elonmusk/status/1884062175280668757.jpg?name=orig
✔ https://d.fixupx.com/elonmusk/status/1884062175280668757:orig
✔ https://d.fixupx.com/elonmusk/status/1884062175280668757.jpg:orig
✔ https://d.fixupx.com/elonmusk/status/1884062175280668757/photo/1?name=orig
✔ https://d.fixupx.com/elonmusk/status/1884062175280668757/photo/1.jpg?name=orig
❌ https://d.fixupx.com/elonmusk/status/1884062175280668757/photo/1:orig
❌ https://d.fixupx.com/elonmusk/status/1884062175280668757/photo/1.jpg:orig

This PR makes the matching regular expression more relaxed, so it can match the above situation.

![image](https://github.com/user-attachments/assets/5304d723-d4d6-46fc-935d-ab543822efc5)
