### PR TITLE
Add `id_str` to media objects in API responses

### DIFF
--- a/src/helpers/media.ts
+++ b/src/helpers/media.ts
@@ -10,7 +10,7 @@ export const processMedia = (c: Context, media: TweetMedia): APIPhoto | APIVideo
   if (media.type === 'photo') {
     return {
       type: 'photo',
-      id_str: media.id_str,
+      id: media.id_str,
       url: formatImageUrl(media.media_url_https),
       width: media.original_info?.width,
       height: media.original_info?.height,
@@ -42,7 +42,7 @@ export const processMedia = (c: Context, media: TweetMedia): APIPhoto | APIVideo
     if (media.type === 'animated_gif' && shouldTranscodeGifs) {
       return {
         type: 'gif',
-        id_str: media.id_str,
+        id: media.id_str,
         url: media.media_url_https,
         width: media.original_info?.width,
         height: media.original_info?.height,
@@ -53,7 +53,7 @@ export const processMedia = (c: Context, media: TweetMedia): APIPhoto | APIVideo
       };
     }
     return {
-      id_str: media.id_str,
+      id: media.id_str,
       url: bestVariant?.url || '',
       thumbnail_url: media.media_url_https,
       duration: (media.video_info?.duration_millis || 0) / 1000,

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -134,6 +134,7 @@ declare interface APIPoll {
 }
 
 declare interface APIMedia {
+  id?: string;
   type: string;
   url: string;
   width: number;
@@ -142,14 +143,12 @@ declare interface APIMedia {
 
 declare interface APIPhoto extends APIMedia {
   type: 'photo' | 'gif';
-  id_str?: string;
   transcode_url?: string;
   altText?: string;
 }
 
 declare interface APIVideo extends APIMedia {
   type: 'video' | 'gif';
-  id_str?: string;
   thumbnail_url: string;
   format: string;
   duration: number;


### PR DESCRIPTION
# Add `id_str` to media objects in API responses

Closes #1684

## Summary
This PR exposes a stable media identifier (`id_str`) on media objects returned by the Twitter API response, making it easier for clients to uniquely reference and correlate individual photos/videos/GIFs in `tweet.media.photos`, `tweet.media.videos`, and `tweet.media.all`.

## Changes
- **Types**
  - Add `id_str?: string` to APIPhoto
  - Add `id_str?: string` to APIVideo
- **Twitter media construction**
  - Populate `id_str` from upstream `TweetMedia.id_str` inside processMedia() for:
    - [photos](https://github.com/steven-vvv/FxEmbed-pr/blob/464202a8212caff8882d8634e623b7f3271ede4e/src/helpers/media.ts#L13)
    - [videos](https://github.com/steven-vvv/FxEmbed-pr/blob/464202a8212caff8882d8634e623b7f3271ede4e/src/helpers/media.ts#L56)
    - [GIFs](https://github.com/steven-vvv/FxEmbed-pr/blob/464202a8212caff8882d8634e623b7f3271ede4e/src/helpers/media.ts#L45) (both transcoded and non-transcoded outputs)

## Compatibility / API Notes
- `id_str` is added as an optional field to avoid forcing updates in other providers/paths that also construct APIPhoto/APIVideo objects under strict TypeScript settings.
- For Twitter responses produced via the main media processing path, `id_str` is consistently populated from the upstream Twitter media entity.

## Why
Clients currently cannot reliably distinguish media items across the response without a media identifier. Twitter provides `id_str` on media entities and it is already referenced in other parts of the response-building pipeline, so surfacing it in the API output improves usability and parity with other implementations.

## Testing
- No new automated tests added.
- Suggested verification:
  - Fetch a tweet containing multiple photos/videos/GIFs and confirm each media object includes `id_str` in the API response.

## Files touched
- [src/types/types.d.ts](https://github.com/steven-vvv/FxEmbed-pr/blob/464202a8212caff8882d8634e623b7f3271ede4e/src/types/types.d.ts)
- [src/helpers/media.ts](https://github.com/steven-vvv/FxEmbed-pr/blob/464202a8212caff8882d8634e623b7f3271ede4e/src/helpers/media.ts)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Added unique identifier fields to media data structures, including photos, videos, and animated content types
  * Implemented consistent ID field propagation throughout API response objects to enhance media identification and organization capabilities
  * Updated media interfaces to support improved tracking and reference of media items across the system

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds optional `id` to API media types and populates it from `TweetMedia.id_str` for photos, videos, and GIFs.
> 
> - **Types** (`src/types/types.d.ts`):
>   - Add optional `id` to `APIMedia` (propagates to `APIPhoto`/`APIVideo`).
> - **Twitter media processing** (`src/helpers/media.ts`):
>   - Populate `id` with `media.id_str` for:
>     - `photo` outputs in `processMedia()`.
>     - `animated_gif` (transcoded) outputs.
>     - `video`/`animated_gif` (non-transcoded) outputs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d231a6f7bcc42dd2577bb5a955259704110c88a7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->