### PR TITLE
fix(twitter-proxy): correct endpoint and variables in Discord exception alerts

### DIFF
--- a/src/providers/twitter/proxy/discord.ts
+++ b/src/providers/twitter/proxy/discord.ts
@@ -3,11 +3,23 @@ import type { ProxyEnv } from './types';
 /** Discord embed field values max out at 1024 chars. */
 const DISCORD_FIELD_TRUNCATE = 1000;
 
+/**
+ * Truncates a string for use in a Discord embed field, appending an ellipsis when it exceeds the field length limit.
+ *
+ * @param s - The input string to truncate
+ * @returns The original string if its length is less than or equal to 1000, otherwise the first 1000 characters followed by an ellipsis
+ */
 function truncateForDiscordField(s: string): string {
   if (s.length <= DISCORD_FIELD_TRUNCATE) return s;
   return s.slice(0, DISCORD_FIELD_TRUNCATE) + '…';
 }
 
+/**
+ * Wraps a GraphQL variables string in a fenced code block or returns a placeholder when the input is empty.
+ *
+ * @param variablesDisplay - The raw variables text to format (may be empty or contain JSON/other text)
+ * @returns The formatted string: a placeholder "_(no GraphQL `variables` param and empty query string)_" when the trimmed input is empty, otherwise a fenced code block containing the original `variablesDisplay`. If the trimmed input starts with `{` or `[` the code block is marked with the `json` language.
+ */
 function variablesCodeBlock(variablesDisplay: string): string {
   const trimmed = variablesDisplay.trim();
   if (trimmed.length === 0) {
@@ -17,6 +29,17 @@ function variablesCodeBlock(variablesDisplay: string): string {
   return '```' + lang + (lang ? '\n' : '') + variablesDisplay + '\n```';
 }
 
+/**
+ * Sends a formatted alert to a Discord webhook about a failed request.
+ *
+ * If `env.EXCEPTION_DISCORD_WEBHOOK` is falsy, the function returns immediately and no request is sent.
+ *
+ * @param env - Environment object that must include `EXCEPTION_DISCORD_WEBHOOK` (the webhook URL)
+ * @param username - Account identifier to display (will be obfuscated in the embed)
+ * @param requestPath - Original request path used to produce the "Endpoint" embed field
+ * @param errors - Error payload to include in the "Errors" embed field (serialized as JSON)
+ * @param variablesDisplay - Raw GraphQL variables string to include in the "Variables" embed field (may be wrapped or replaced with a placeholder)
+ */
 export async function sendDiscordAlert(
   env: ProxyEnv,
   username: string,

--- a/src/providers/twitter/proxy/discord.ts
+++ b/src/providers/twitter/proxy/discord.ts
@@ -1,5 +1,22 @@
 import type { ProxyEnv } from './types';
 
+/** Discord embed field values max out at 1024 chars. */
+const DISCORD_FIELD_TRUNCATE = 1000;
+
+function truncateForDiscordField(s: string): string {
+  if (s.length <= DISCORD_FIELD_TRUNCATE) return s;
+  return s.slice(0, DISCORD_FIELD_TRUNCATE) + '…';
+}
+
+function variablesCodeBlock(variablesDisplay: string): string {
+  const trimmed = variablesDisplay.trim();
+  if (trimmed.length === 0) {
+    return '_(no GraphQL `variables` param and empty query string)_';
+  }
+  const lang = trimmed.startsWith('{') || trimmed.startsWith('[') ? 'json' : '';
+  return '```' + lang + (lang ? '\n' : '') + variablesDisplay + '\n```';
+}
+
 export async function sendDiscordAlert(
   env: ProxyEnv,
   username: string,
@@ -10,6 +27,7 @@ export async function sendDiscordAlert(
   if (!env.EXCEPTION_DISCORD_WEBHOOK) return;
 
   console.log('Sending Discord webhook');
+  const endpointDisplay = truncateForDiscordField((requestPath ?? '').replace(/^\//, '') || 'idk');
   const body = JSON.stringify({
     content: `@everyone`,
     embeds: [
@@ -24,7 +42,7 @@ export async function sendDiscordAlert(
           },
           {
             name: 'Endpoint',
-            value: (requestPath ?? '').match(/\w+$/g)?.[0] ?? 'idk',
+            value: endpointDisplay,
             inline: true
           },
           {
@@ -34,7 +52,7 @@ export async function sendDiscordAlert(
           },
           {
             name: 'Variables',
-            value: '```json\n' + variablesDisplay + '\n```',
+            value: variablesCodeBlock(variablesDisplay),
             inline: false
           }
         ]

--- a/src/providers/twitter/proxy/discord.ts
+++ b/src/providers/twitter/proxy/discord.ts
@@ -18,7 +18,7 @@ function truncateForDiscordField(s: string): string {
  * Wraps a GraphQL variables string in a fenced code block or returns a placeholder when the input is empty.
  *
  * @param variablesDisplay - The raw variables text to format (may be empty or contain JSON/other text)
- * @returns The formatted string: a placeholder "_(no GraphQL `variables` param and empty query string)_" when the trimmed input is empty, otherwise a fenced code block containing the original `variablesDisplay`. If the trimmed input starts with `{` or `[` the code block is marked with the `json` language.
+ * @returns The formatted string: a placeholder "_(no GraphQL `variables` param and empty query string)_" when the trimmed input is empty, otherwise a fenced code block containing the trimmed variables (truncated for Discord field limits). If the trimmed input starts with `{` or `[` the code block is marked with the `json` language.
  */
 function variablesCodeBlock(variablesDisplay: string): string {
   const trimmed = variablesDisplay.trim();
@@ -26,7 +26,8 @@ function variablesCodeBlock(variablesDisplay: string): string {
     return '_(no GraphQL `variables` param and empty query string)_';
   }
   const lang = trimmed.startsWith('{') || trimmed.startsWith('[') ? 'json' : '';
-  return '```' + lang + (lang ? '\n' : '') + variablesDisplay + '\n```';
+  const bounded = truncateForDiscordField(trimmed);
+  return '```' + lang + (lang ? '\n' : '') + bounded + '\n```';
 }
 
 /**

--- a/src/providers/twitter/proxy/handler.ts
+++ b/src/providers/twitter/proxy/handler.ts
@@ -22,7 +22,13 @@ function asRecord(value: unknown): Record<string, unknown> | undefined {
 }
 
 /**
- * Authenticated X API proxy (formerly elongator worker). Forwards to api.x.com with session cookies.
+ * Proxies an incoming request to api.x.com using session credentials, applying cookies, optional CSRF and x-client-transaction-id headers, and retrying with different accounts when upstream errors occur.
+ *
+ * May send a Discord alert if configured, strip leaked usernames from responses, and return a synthetic error response after repeated failures.
+ *
+ * @param request - The original incoming Request to forward
+ * @param env - Environment/configuration values used by the proxy (for example webhook and feature flags)
+ * @returns The response returned to the caller reflecting the proxied api.x.com response (status, headers, and possibly transformed body) or an error response when retries are exhausted
  */
 export async function proxyTwitterRequest(request: Request, env: ProxyEnv): Promise<Response> {
   const url = new URL(request.url);

--- a/src/providers/twitter/proxy/handler.ts
+++ b/src/providers/twitter/proxy/handler.ts
@@ -132,11 +132,16 @@ export async function proxyTwitterRequest(request: Request, env: ProxyEnv): Prom
           }
         }
 
-        let variables = url.searchParams.get('variables') ?? '';
+        let variablesDisplay = url.searchParams.get('variables') ?? '';
         try {
-          variables = JSON.stringify(JSON.parse(variables), null, 2);
+          if (variablesDisplay) {
+            variablesDisplay = JSON.stringify(JSON.parse(variablesDisplay), null, 2);
+          }
         } catch {
-          variables = url.search;
+          variablesDisplay = url.search;
+        }
+        if (!variablesDisplay) {
+          variablesDisplay = url.search;
         }
 
         if (env.EXCEPTION_DISCORD_WEBHOOK && errors) {
@@ -146,7 +151,7 @@ export async function proxyTwitterRequest(request: Request, env: ProxyEnv): Prom
               username,
               requestPath,
               asRecord(json)?.['errors'],
-              variables
+              variablesDisplay
             );
           } catch (alertErr) {
             console.error('Discord exception alert failed', {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Exception webhooks for the authenticated X API proxy showed **Endpoint: `json`** and **Variables: `json`** for many REST (non-GraphQL) failures. That was misleading logging, not proof that the wrong API was called.

## Root cause

1. **Endpoint** used `(requestPath).match(/\w+$/)`, which returns only the **last path segment**. For paths like `/1.1/statuses/show.json` that segment is literally `json`.
2. **Variables** only read the GraphQL `variables` query param. REST endpoints use normal query keys; when that param was missing and the query was empty, the embed showed an empty ` ```json ` block — some Telegram clients render that as the word `json`.

## Changes

- **Endpoint**: show the full path (strip leading `/`, truncate to Discord field limits).
- **Variables**: after parsing GraphQL `variables` when present, fall back to the full `url.search` when empty; use a plain fenced block for non-JSON query strings; show an explicit message when there is no query at all.

Twitter error **131** remains an upstream internal error; this PR only fixes how we report the request that failed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-161ab0dc-01f8-45ef-991d-a9a12f803160"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-161ab0dc-01f8-45ef-991d-a9a12f803160"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling and fallback for GraphQL variables extraction used in alert messages to avoid empty or misleading content.

* **New Features**
  * Discord alert formatting: safer endpoint display with truncation for long values.
  * Smart variables rendering in Discord: shows a clear placeholder when empty and chooses appropriate fenced code formatting for JSON or plain text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->