### PR TITLE
Add Bluesky trending topics to FxBluesky API (`GET /2/trends`)

### DIFF
--- a/src/providers/bluesky/client.ts
+++ b/src/providers/bluesky/client.ts
@@ -310,3 +310,21 @@ export const fetchGetLikes = async (params: {
   }
   return result;
 };
+
+/** Public AppView; `limit` is typically 1–25 per upstream. */
+export const fetchTrendingTopics = async (params: {
+  limit: number;
+}): Promise<
+  { ok: true; data: BlueskyGetTrendingTopicsResponse } | { ok: false; status: number; body: string }
+> => {
+  const result = await fetchXrpc<BlueskyGetTrendingTopicsResponse>(
+    'app.bsky.unspecced.getTrendingTopics',
+    {
+      limit: params.limit
+    }
+  );
+  if (!result.ok) {
+    console.log('Bluesky getTrendingTopics failed', result.status, result.body?.slice?.(0, 200));
+  }
+  return result;
+};

--- a/src/providers/bluesky/client.ts
+++ b/src/providers/bluesky/client.ts
@@ -475,17 +475,17 @@ export const fetchGetLikes = async (
   return result;
 };
 
-/** Public AppView; `limit` is typically 1–25 per upstream. */
-export const fetchTrendingTopics = async (params: {
-  limit: number;
-}): Promise<
+/** Public AppView (with optional proxy fallback); `limit` is typically 1–25 per upstream. */
+export const fetchTrendingTopics = async (
+  params: { limit: number },
+  opts?: BlueskyFetchOpts
+): Promise<
   { ok: true; data: BlueskyGetTrendingTopicsResponse } | { ok: false; status: number; body: string }
 > => {
-  const result = await fetchXrpc<BlueskyGetTrendingTopicsResponse>(
+  const result = await executeBlueskyXrpc<BlueskyGetTrendingTopicsResponse>(
     'app.bsky.unspecced.getTrendingTopics',
-    {
-      limit: params.limit
-    }
+    { limit: params.limit },
+    opts?.credentialKey
   );
   if (!result.ok) {
     console.log('Bluesky getTrendingTopics failed', result.status, result.body?.slice?.(0, 200));

--- a/src/providers/bluesky/trends.ts
+++ b/src/providers/bluesky/trends.ts
@@ -1,0 +1,117 @@
+import { fetchTrendingTopics } from './client';
+
+export type BlueskyTrendsFeedKind = 'trending' | 'suggested';
+
+export const BLUESKY_TRENDS_FEED_KINDS: BlueskyTrendsFeedKind[] = ['trending', 'suggested'];
+
+const BS_APP_ORIGIN = 'https://bsky.app';
+
+function topicLinkAsContext(link: string | undefined): string | null {
+  if (!link || typeof link !== 'string') {
+    return null;
+  }
+  const path = link.startsWith('/') ? link : `/${link}`;
+  return `${BS_APP_ORIGIN}${path}`;
+}
+
+function buildContext(linkContext: string | null, label: string | null): string | null {
+  if (label && linkContext) {
+    return `${label} · ${linkContext}`;
+  }
+  return label ?? linkContext;
+}
+
+function rowToApiTrend(
+  row: BlueskyTrendingTopicRow,
+  oneBasedRank: number,
+  contextLabel: string | null
+): APITrend | null {
+  const name = row.topic;
+  if (!name || typeof name !== 'string') {
+    return null;
+  }
+  return {
+    name,
+    rank: String(oneBasedRank),
+    context: buildContext(topicLinkAsContext(row.link), contextLabel)
+  };
+}
+
+/**
+ * Trending topic labels from Bluesky `app.bsky.unspecced.getTrendingTopics`.
+ * `type=trending` returns live topics first, then fills from suggested feeds up to `count`.
+ * `type=suggested` returns only the suggested list.
+ */
+export const blueskyTrendsAPI = async (
+  kind: BlueskyTrendsFeedKind,
+  count: number
+): Promise<APITrendsResponse> => {
+  const cappedCount = Math.min(50, Math.max(1, count));
+  const upstreamLimit = Math.min(25, Math.max(1, cappedCount));
+
+  const result = await fetchTrendingTopics({ limit: upstreamLimit });
+  if (!result.ok) {
+    return {
+      code: result.status === 404 ? 404 : 500,
+      timeline_type: kind,
+      trends: [],
+      cursor: { top: null, bottom: null },
+      message:
+        result.status === 404
+          ? 'Trending topics unavailable'
+          : 'Failed to load trending topics from Bluesky'
+    };
+  }
+
+  const safeTopics = Array.isArray(result.data.topics) ? result.data.topics : [];
+  const safeSuggested = Array.isArray(result.data.suggested) ? result.data.suggested : [];
+
+  const trends: APITrend[] = [];
+
+  if (kind === 'suggested') {
+    let rank = 0;
+    for (const row of safeSuggested) {
+      const t = rowToApiTrend(row, rank + 1, 'Suggested feed');
+      if (t) {
+        trends.push(t);
+        rank += 1;
+        if (rank >= cappedCount) break;
+      }
+    }
+  } else {
+    let rank = 0;
+    for (const row of safeTopics) {
+      const t = rowToApiTrend(row, rank + 1, null);
+      if (t) {
+        trends.push(t);
+        rank += 1;
+        if (rank >= cappedCount) break;
+      }
+    }
+    for (const row of safeSuggested) {
+      if (rank >= cappedCount) break;
+      const t = rowToApiTrend(row, rank + 1, 'Suggested feed');
+      if (t) {
+        trends.push(t);
+        rank += 1;
+      }
+    }
+  }
+
+  if (!trends.length) {
+    return {
+      code: 404,
+      timeline_type: kind,
+      trends: [],
+      cursor: { top: null, bottom: null },
+      message: 'No trending topics in upstream response'
+    };
+  }
+
+  return {
+    code: 200,
+    timeline_type: kind,
+    trends,
+    cursor: { top: null, bottom: null }
+  };
+};

--- a/src/providers/bluesky/trends.ts
+++ b/src/providers/bluesky/trends.ts
@@ -1,3 +1,4 @@
+import type { Context } from 'hono';
 import { fetchTrendingTopics } from './client';
 
 export type BlueskyTrendsFeedKind = 'trending' | 'suggested';
@@ -44,12 +45,16 @@ function rowToApiTrend(
  */
 export const blueskyTrendsAPI = async (
   kind: BlueskyTrendsFeedKind,
-  count: number
+  count: number,
+  c: Context
 ): Promise<APITrendsResponse> => {
   const cappedCount = Math.min(50, Math.max(1, count));
   const upstreamLimit = Math.min(25, Math.max(1, cappedCount));
 
-  const result = await fetchTrendingTopics({ limit: upstreamLimit });
+  const result = await fetchTrendingTopics(
+    { limit: upstreamLimit },
+    { credentialKey: c.env?.CREDENTIAL_KEY }
+  );
   if (!result.ok) {
     return {
       code: result.status === 404 ? 404 : 500,

--- a/src/realms/bluesky-api/handlers.ts
+++ b/src/realms/bluesky-api/handlers.ts
@@ -187,7 +187,7 @@ export const blueskyTrendsAPIRequest: RouteHandler<typeof blueskyTrendsV2Route> 
   const query = c.req.valid('query');
   const type = query.type ?? 'trending';
   const count = query.count ?? 20;
-  const trendsResponse = await blueskyTrendsAPI(type, count);
+  const trendsResponse = await blueskyTrendsAPI(type, count, c);
   const { httpStatus, payload } = normalizeApiJsonResponse(
     trendsResponse,
     [200, 400, 404, 500] as const,

--- a/src/realms/bluesky-api/handlers.ts
+++ b/src/realms/bluesky-api/handlers.ts
@@ -17,6 +17,7 @@ import {
   blueskyProfileFollowingAPI
 } from '../../providers/bluesky/profileFollowers';
 import { blueskySearchAPI } from '../../providers/bluesky/search';
+import { blueskyTrendsAPI } from '../../providers/bluesky/trends';
 import { blueskyStatusLikesAPI } from '../../providers/bluesky/statusLikes';
 import { blueskyStatusRepostsAPI } from '../../providers/bluesky/statusReposts';
 import {
@@ -28,6 +29,7 @@ import {
   blueskyProfileStatusesV2Route,
   blueskyProfileV2Route,
   blueskySearchV2Route,
+  blueskyTrendsV2Route,
   blueskyStatusLikesV2Route,
   blueskyStatusRepostsV2Route,
   blueskyStatusV2Route,
@@ -179,6 +181,23 @@ export const blueskySearchAPIRequest: RouteHandler<typeof blueskySearchV2Route> 
     c.header(header, value);
   }
   return jsonAfterNormalize<typeof blueskySearchV2Route>(c, payload, httpStatus);
+};
+
+export const blueskyTrendsAPIRequest: RouteHandler<typeof blueskyTrendsV2Route> = async c => {
+  const query = c.req.valid('query');
+  const type = query.type ?? 'trending';
+  const count = query.count ?? 20;
+  const trendsResponse = await blueskyTrendsAPI(type, count);
+  const { httpStatus, payload } = normalizeApiJsonResponse(
+    trendsResponse,
+    [200, 400, 404, 500] as const,
+    'blueskyTrendsAPIRequest'
+  );
+  c.status(httpStatus);
+  for (const [header, value] of Object.entries(Constants.API_RESPONSE_HEADERS)) {
+    c.header(header, value);
+  }
+  return jsonAfterNormalize<typeof blueskyTrendsV2Route>(c, payload, httpStatus);
 };
 
 export const blueskyProfileFollowersAPIRequest: RouteHandler<

--- a/src/realms/bluesky-api/router.ts
+++ b/src/realms/bluesky-api/router.ts
@@ -12,6 +12,7 @@ import {
   blueskyProfileStatusesV2Route,
   blueskyProfileV2Route,
   blueskySearchV2Route,
+  blueskyTrendsV2Route,
   blueskyStatusLikesV2Route,
   blueskyStatusRepostsV2Route,
   blueskyStatusV2Route,
@@ -26,6 +27,7 @@ import {
   blueskyProfileMediaAPIRequest,
   blueskyProfileStatusesAPIRequest,
   blueskySearchAPIRequest,
+  blueskyTrendsAPIRequest,
   blueskyStatusAPIRequest,
   blueskyStatusLikesAPIRequest,
   blueskyStatusRepostsAPIRequest,
@@ -55,6 +57,7 @@ blueskyApi.openapi(blueskyStatusLikesV2Route, blueskyStatusLikesAPIRequest);
 blueskyApi.openapi(blueskyThreadV2Route, blueskyThreadAPIRequest);
 blueskyApi.openapi(blueskyConversationV2Route, blueskyConversationAPIRequest);
 blueskyApi.openapi(blueskySearchV2Route, blueskySearchAPIRequest);
+blueskyApi.openapi(blueskyTrendsV2Route, blueskyTrendsAPIRequest);
 blueskyApi.openapi(blueskyProfileV2Route, blueskyProfileAPIRequest);
 blueskyApi.openapi(blueskyProfileFollowersV2Route, blueskyProfileFollowersAPIRequest);
 blueskyApi.openapi(blueskyProfileFollowingV2Route, blueskyProfileFollowingAPIRequest);

--- a/src/realms/bluesky-api/routes.ts
+++ b/src/realms/bluesky-api/routes.ts
@@ -4,10 +4,15 @@ import {
   APIUserListResultsSchema,
   ApiQueryErrorSchema,
   APISearchResultsBlueskySchema,
+  APITrendsResponseSchema,
   SocialConversationBlueskySchema,
   SocialThreadBlueskySchema,
   UserAPIResponseSchema
 } from '../api/schemas';
+import {
+  BLUESKY_TRENDS_FEED_KINDS,
+  type BlueskyTrendsFeedKind
+} from '../../providers/bluesky/trends';
 
 const langQuery = z.object({
   lang: z.string().optional().openapi({
@@ -292,6 +297,50 @@ export const blueskySearchV2Route = createRoute({
     500: {
       description: 'Upstream or processing error',
       content: { 'application/json': { schema: APISearchResultsBlueskySchema } }
+    }
+  }
+});
+
+const blueskyTrendsTypeDescription = `Trend list. \`trending\` returns Bluesky live topics first, then suggested topic feeds to fill \`count\`. \`suggested\` returns only suggested feeds. Upstream: \`app.bsky.unspecced.getTrendingTopics\` (max 25 rows per request).`;
+
+export const blueskyTrendsV2Route = createRoute({
+  method: 'get',
+  path: '/2/trends',
+  summary: 'Trending topics (Bluesky)',
+  description:
+    'Returns trending topic labels and suggested topic feeds from the Bluesky public AppView, in the same envelope as FxTwitter `GET /2/trends` (`code`, `timeline_type`, `trends`, `cursor`). Each trend’s `context` includes a bsky.app URL to the topic feed when the upstream provides a `link`.',
+  request: {
+    query: z.object({
+      type: z
+        .enum(BLUESKY_TRENDS_FEED_KINDS as [BlueskyTrendsFeedKind, ...BlueskyTrendsFeedKind[]])
+        .optional()
+        .openapi({
+          description: blueskyTrendsTypeDescription,
+          default: 'trending',
+          example: 'trending'
+        }),
+      count: z.coerce.number().int().min(1).max(50).optional().openapi({
+        description: 'Number of trends (default 20, max 50)',
+        default: 20
+      })
+    })
+  },
+  responses: {
+    200: {
+      description: 'Trends payload',
+      content: { 'application/json': { schema: APITrendsResponseSchema } }
+    },
+    400: {
+      description: 'Invalid query parameters (e.g. `type` or `count` out of allowed range)',
+      content: { 'application/json': { schema: ApiQueryErrorSchema } }
+    },
+    404: {
+      description: 'Trends unavailable or empty upstream list',
+      content: { 'application/json': { schema: APITrendsResponseSchema } }
+    },
+    500: {
+      description: 'Upstream or processing error',
+      content: { 'application/json': { schema: APITrendsResponseSchema } }
     }
   }
 });

--- a/src/types/vendor/bluesky.d.ts
+++ b/src/types/vendor/bluesky.d.ts
@@ -280,6 +280,17 @@ declare type BlueskySearchPostsResponse = {
   hitsTotal?: number;
 };
 
+/** `app.bsky.unspecced.getTrendingTopics` (subset; public AppView). */
+declare type BlueskyTrendingTopicRow = {
+  topic: string;
+  link?: string;
+};
+
+declare type BlueskyGetTrendingTopicsResponse = {
+  topics?: BlueskyTrendingTopicRow[];
+  suggested?: BlueskyTrendingTopicRow[];
+};
+
 /** `app.bsky.feed.getAuthorFeed` `filter` lexicon values used by FxBluesky. */
 declare type BlueskyAuthorFeedFilter =
   | 'posts_no_replies'

--- a/test/bluesky.api.test.ts
+++ b/test/bluesky.api.test.ts
@@ -15,6 +15,8 @@ import repostersProfilesBatch from './fixtures/bluesky/reposters-profiles-batch.
 import getLikes from './fixtures/bluesky/get-likes.json';
 import likersProfilesBatch from './fixtures/bluesky/likers-profiles-batch.json';
 import conversationThread from './fixtures/bluesky/conversation-thread.json';
+import getTrendingTopics from './fixtures/bluesky/get-trending-topics.json';
+import type { APITrendsResponse } from '../src/realms/api/schemas';
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -129,6 +131,95 @@ test('GET /2/search returns results and cursor.bottom', async () => {
   expect(body.results.length).toBe(1);
   expect(body.results[0].id).toBe('rkeysearch');
   expect(body.results[0].text).toContain('Search hit fixture');
+});
+
+test('GET /2/trends maps Bluesky getTrendingTopics to APITrendsResponse', async () => {
+  vi.spyOn(globalThis, 'fetch').mockImplementation(async (input: RequestInfo) => {
+    const u = typeof input === 'string' ? input : input.url;
+    if (u.includes('app.bsky.unspecced.getTrendingTopics')) {
+      expect(u).toContain('limit=4');
+      return new Response(JSON.stringify(getTrendingTopics), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+    throw new Error(`Unexpected fetch: ${u}`);
+  });
+
+  const res = await app.request('https://api.fxbsky.app/2/trends?count=4', {
+    headers: { 'User-Agent': 'FxEmbedTest/1.0' }
+  });
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as APITrendsResponse;
+  expect(body.code).toBe(200);
+  expect(body.timeline_type).toBe('trending');
+  expect(body.trends).toHaveLength(4);
+  expect(body.trends[0].name).toBe('Topic One');
+  expect(body.trends[0].context).toBe('https://bsky.app/profile/trending.bsky.app/feed/1');
+  expect(body.trends[1].name).toBe('Topic Two');
+  expect(body.trends[2].name).toBe('Suggested A');
+  expect(body.trends[2].context).toContain('Suggested feed');
+  expect(body.trends[2].context).toContain('https://bsky.app/profile/bsky.app/feed/with-friends');
+  expect(body.cursor.top).toBeNull();
+  expect(body.cursor.bottom).toBeNull();
+});
+
+test('GET /2/trends?type=suggested returns only suggested rows', async () => {
+  vi.spyOn(globalThis, 'fetch').mockImplementation(async (input: RequestInfo) => {
+    const u = typeof input === 'string' ? input : input.url;
+    if (u.includes('app.bsky.unspecced.getTrendingTopics')) {
+      expect(u).toContain('limit=2');
+      return new Response(JSON.stringify(getTrendingTopics), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+    throw new Error(`Unexpected fetch: ${u}`);
+  });
+
+  const res = await app.request('https://api.fxbsky.app/2/trends?type=suggested&count=2', {
+    headers: { 'User-Agent': 'FxEmbedTest/1.0' }
+  });
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as APITrendsResponse;
+  expect(body.timeline_type).toBe('suggested');
+  expect(body.trends).toHaveLength(2);
+  expect(body.trends[0].name).toBe('Suggested A');
+  expect(body.trends[0].context).toContain('Suggested feed');
+  expect(body.trends[1].name).toBe('Suggested B');
+});
+
+test('GET /2/trends returns 404 when upstream topics are empty', async () => {
+  vi.spyOn(globalThis, 'fetch').mockImplementation(async (input: RequestInfo) => {
+    const u = typeof input === 'string' ? input : input.url;
+    if (u.includes('app.bsky.unspecced.getTrendingTopics')) {
+      return new Response(JSON.stringify({ topics: [], suggested: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+    throw new Error(`Unexpected fetch: ${u}`);
+  });
+
+  const res = await app.request('https://api.fxbsky.app/2/trends', {
+    headers: { 'User-Agent': 'FxEmbedTest/1.0' }
+  });
+  expect(res.status).toBe(404);
+});
+
+test('GET /2/trends returns 500 when upstream errors', async () => {
+  vi.spyOn(globalThis, 'fetch').mockImplementation(async (input: RequestInfo) => {
+    const u = typeof input === 'string' ? input : input.url;
+    if (u.includes('app.bsky.unspecced.getTrendingTopics')) {
+      return new Response('upstream', { status: 502 });
+    }
+    throw new Error(`Unexpected fetch: ${u}`);
+  });
+
+  const res = await app.request('https://api.fxbsky.app/2/trends', {
+    headers: { 'User-Agent': 'FxEmbedTest/1.0' }
+  });
+  expect(res.status).toBe(500);
 });
 
 test('GET /2/search passes cursor and feed=top as sort', async () => {

--- a/test/fixtures/bluesky/get-trending-topics.json
+++ b/test/fixtures/bluesky/get-trending-topics.json
@@ -1,0 +1,10 @@
+{
+  "topics": [
+    { "topic": "Topic One", "link": "/profile/trending.bsky.app/feed/1" },
+    { "topic": "Topic Two", "link": "/profile/trending.bsky.app/feed/2" }
+  ],
+  "suggested": [
+    { "topic": "Suggested A", "link": "/profile/bsky.app/feed/with-friends" },
+    { "topic": "Suggested B", "link": "/profile/example.com/feed/aa" }
+  ]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Bluesky did not previously expose trends on the FxBluesky API realm. This change adds `GET /2/trends` on the Bluesky API host, backed by Bluesky public AppView `app.bsky.unspecced.getTrendingTopics`, using the same `APITrendsResponse` envelope as FxTwitter `GET /2/trends`.

## Behavior

- **`type=trending` (default):** Returns live `topics` first, then fills from `suggested` up to `count` (max 50 client-side; upstream request uses `limit` capped at 25).
- **`type=suggested`:** Returns only rows from the upstream `suggested` list.
- **`context`:** Live topics use the resolved `https://bsky.app/...` link when present; suggested rows prefix with `Suggested feed ·` plus the link.

## Follow-up (post–main merge)

Main refactored the Bluesky client to use `executeBlueskyXrpc` + optional proxy fallback. `fetchTrendingTopics` was still calling the removed `fetchXrpc`, which broke `/2/trends` at runtime. A follow-up commit routes trending through `executeBlueskyXrpc` and passes `CREDENTIAL_KEY` from the Hono context like other Bluesky providers.

## Tests

- Vitest coverage in `test/bluesky.api.test.ts` with fixture `test/fixtures/bluesky/get-trending-topics.json` (happy path, suggested-only, empty upstream, upstream error).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-da74ed01-90fb-4a68-8b85-902cb5d23bcc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-da74ed01-90fb-4a68-8b85-902cb5d23bcc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new trending topics API (GET /2/trends) returning live and suggested topics, with feed types "trending" or "suggested" and configurable count (1–50, default 20). Merges live topics with suggested items to fill results; returns 404 when none found and 500 on upstream failure. Included in OpenAPI documentation.
* **Tests**
  * Added integration tests and fixture coverage validating mapping, filtering, and error responses for the trends endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->