### PR TITLE
feat: Improve Bluesky API resiliency

### DIFF
--- a/credentials.example.json
+++ b/credentials.example.json
@@ -7,5 +7,14 @@
         "username": "account_screen_name"
       }
     ]
+  },
+  "bluesky": {
+    "accounts": [
+      {
+        "identifier": "your.handle.bsky.social",
+        "appPassword": "xxxx-xxxx-xxxx-xxxx",
+        "service": "https://bsky.social"
+      }
+    ]
   }
 }

--- a/src/providers/bluesky/client.ts
+++ b/src/providers/bluesky/client.ts
@@ -144,7 +144,7 @@ async function executeBlueskyXrpc<T>(
     const accessJwt = await getBlueskyAccessJwt(cred);
     if (!accessJwt) continue;
 
-    const attempt = await fetchXrpcOnce<T>(cred.service, path, params, {
+    let attempt = await fetchXrpcOnce<T>(cred.service, path, params, {
       authorization: `Bearer ${accessJwt}`,
       timeoutMs
     });
@@ -159,6 +159,19 @@ async function executeBlueskyXrpc<T>(
 
     if (attempt.status === 401) {
       invalidateBlueskySession(cred);
+      const freshJwt = await getBlueskyAccessJwt(cred);
+      if (freshJwt) {
+        attempt = await fetchXrpcOnce<T>(cred.service, path, params, {
+          authorization: `Bearer ${freshJwt}`,
+          timeoutMs
+        });
+        if (attempt.ok) {
+          return { ok: true, data: attempt.data };
+        }
+        if (isNotFoundError(attempt.status, attempt.body)) {
+          return { ok: false, status: attempt.status, body: attempt.body };
+        }
+      }
       continue;
     }
   }

--- a/src/providers/bluesky/client.ts
+++ b/src/providers/bluesky/client.ts
@@ -1,59 +1,188 @@
 import { Constants } from '../../constants';
+import {
+  getShuffledBlueskyAccounts,
+  hasBlueskyProxyAccounts,
+  hasBundledEncryptedCredentials,
+  initCredentials
+} from '../twitter/proxy/credentials';
+import { getBlueskyAccessJwt, invalidateBlueskySession } from './session';
 
-const DEFAULT_TIMEOUT_MS = 12_000;
+/** Per-upstream request cap during partial outages (public first, then proxy PDS). */
+export const BLUESKY_UPSTREAM_TIMEOUT_MS = 4_000;
+
+export type BlueskyFetchOpts = {
+  credentialKey?: string;
+};
 
 export type XrpcErrorBody = {
   error?: string;
   message?: string;
 };
 
-async function fetchXrpc<T>(
-  path: string,
-  searchParams: Record<string, string | number | undefined>
-): Promise<{ ok: true; data: T } | { ok: false; status: number; body: string }> {
+type BlueskyXrpcParams = Record<string, string | number | undefined | string[]>;
+
+function trimBaseUrl(base: string): string {
+  return base.replace(/\/$/, '');
+}
+
+function paramsToSearchString(params: BlueskyXrpcParams): string {
   const qs = new URLSearchParams();
-  for (const [k, v] of Object.entries(searchParams)) {
+  for (const [k, v] of Object.entries(params)) {
     if (v === undefined) continue;
-    qs.set(k, String(v));
+    if (Array.isArray(v)) {
+      for (const item of v) qs.append(k, String(item));
+    } else {
+      qs.set(k, String(v));
+    }
   }
-  const url = `${Constants.BLUESKY_API_ROOT}/xrpc/${path}?${qs.toString()}`;
+  return qs.toString();
+}
+
+function buildXrpcUrl(baseUrl: string, path: string, params: BlueskyXrpcParams): string {
+  const qs = paramsToSearchString(params);
+  return `${trimBaseUrl(baseUrl)}/xrpc/${path}?${qs}`;
+}
+
+type XrpcAttemptFail = {
+  ok: false;
+  status: number;
+  body: string;
+  aborted?: boolean;
+};
+
+type XrpcAttemptOk<T> = { ok: true; data: T };
+
+async function fetchXrpcOnce<T>(
+  baseUrl: string,
+  path: string,
+  params: BlueskyXrpcParams,
+  options: { authorization?: string; timeoutMs: number }
+): Promise<XrpcAttemptOk<T> | XrpcAttemptFail> {
+  const url = buildXrpcUrl(baseUrl, path, params);
   const ac = new AbortController();
-  const t = setTimeout(() => ac.abort(), DEFAULT_TIMEOUT_MS);
-  let res: Response;
+  const t = setTimeout(() => ac.abort(), options.timeoutMs);
   try {
-    res = await fetch(url, {
-      signal: ac.signal,
-      headers: { Accept: 'application/json' }
-    });
+    const headers: Record<string, string> = { Accept: 'application/json' };
+    if (options.authorization) headers['Authorization'] = options.authorization;
+    const res = await fetch(url, { signal: ac.signal, headers });
+    clearTimeout(t);
+    const body = await res.text();
+    if (!res.ok) {
+      return { ok: false, status: res.status, body };
+    }
+    try {
+      return { ok: true, data: JSON.parse(body) as T };
+    } catch {
+      return { ok: false, status: 502, body: 'invalid JSON from Bluesky' };
+    }
   } catch (e) {
     clearTimeout(t);
     const msg = e instanceof Error ? e.message : String(e);
-    return { ok: false, status: 504, body: msg };
+    const aborted = e instanceof Error && e.name === 'AbortError';
+    return { ok: false, status: 504, body: msg, aborted };
   }
-  clearTimeout(t);
+}
 
-  if (!res.ok) {
-    const body = await res.text();
-    return { ok: false, status: res.status, body };
-  }
+function isNotFoundError(status: number, body: string): boolean {
+  if (status === 404) return true;
   try {
-    const data = (await res.json()) as T;
-    return { ok: true, data };
+    const j = JSON.parse(body) as { error?: string };
+    const err = j.error ?? '';
+    if (err === 'NotFound' || err === 'RecordNotFound') return true;
   } catch {
-    return { ok: false, status: 502, body: 'invalid JSON from Bluesky' };
+    /* ignore */
   }
+  return false;
+}
+
+function isFallbackEligible(status: number, body: string, aborted?: boolean): boolean {
+  if (isNotFoundError(status, body)) return false;
+  if (aborted) return true;
+  if (status === 429 || status === 502 || status === 503 || status === 504) return true;
+  if (status === 401) return true;
+  return false;
+}
+
+async function executeBlueskyXrpc<T>(
+  path: string,
+  params: BlueskyXrpcParams,
+  credentialKey: string | undefined
+): Promise<{ ok: true; data: T } | { ok: false; status: number; body: string }> {
+  const publicBase = Constants.BLUESKY_API_ROOT;
+  const timeoutMs = BLUESKY_UPSTREAM_TIMEOUT_MS;
+
+  const first = await fetchXrpcOnce<T>(publicBase, path, params, { timeoutMs });
+  if (first.ok) {
+    return { ok: true, data: first.data };
+  }
+  if (isNotFoundError(first.status, first.body)) {
+    return { ok: false, status: first.status, body: first.body };
+  }
+  if (
+    !isFallbackEligible(first.status, first.body, first.aborted) ||
+    !credentialKey?.trim() ||
+    !hasBundledEncryptedCredentials()
+  ) {
+    return { ok: false, status: first.status, body: first.body };
+  }
+
+  await initCredentials(credentialKey);
+  if (!hasBlueskyProxyAccounts()) {
+    return { ok: false, status: first.status, body: first.body };
+  }
+
+  for (const cred of getShuffledBlueskyAccounts()) {
+    const accessJwt = await getBlueskyAccessJwt(cred);
+    if (!accessJwt) continue;
+
+    const attempt = await fetchXrpcOnce<T>(cred.service, path, params, {
+      authorization: `Bearer ${accessJwt}`,
+      timeoutMs
+    });
+
+    if (attempt.ok) {
+      return { ok: true, data: attempt.data };
+    }
+
+    if (isNotFoundError(attempt.status, attempt.body)) {
+      return { ok: false, status: attempt.status, body: attempt.body };
+    }
+
+    if (attempt.status === 401) {
+      invalidateBlueskySession(cred);
+      continue;
+    }
+  }
+
+  return { ok: false, status: first.status, body: first.body };
+}
+
+/** Parse JSON body after a successful logical XRPC (used by helpers that return empty defaults). */
+async function executeBlueskyGetJson<T>(
+  path: string,
+  params: BlueskyXrpcParams,
+  credentialKey: string | undefined
+): Promise<T | null> {
+  const r = await executeBlueskyXrpc<T>(path, params, credentialKey);
+  if (!r.ok) return null;
+  return r.data;
 }
 
 export const fetchPostThread = async (
   atUri: string,
   depth = 10,
-  parentHeight?: number
+  parentHeight?: number,
+  opts?: BlueskyFetchOpts
 ): Promise<BlueskyThreadResponse | null> => {
-  const result = await fetchXrpc<BlueskyThreadResponse>('app.bsky.feed.getPostThread', {
-    uri: atUri,
-    depth,
-    parentHeight
-  });
+  const result = await executeBlueskyXrpc<BlueskyThreadResponse>(
+    'app.bsky.feed.getPostThread',
+    {
+      uri: atUri,
+      depth,
+      parentHeight
+    },
+    opts?.credentialKey
+  );
   if (!result.ok) {
     console.log('Bluesky getPostThread failed', result.status, result.body?.slice?.(0, 200));
     return null;
@@ -62,113 +191,102 @@ export const fetchPostThread = async (
 };
 
 /** Batch-resolve post views (quotes not hydrated in thread, etc.). */
-export const fetchPostsByUris = async (uris: string[]): Promise<BlueskyPost[]> => {
+export const fetchPostsByUris = async (
+  uris: string[],
+  opts?: BlueskyFetchOpts
+): Promise<BlueskyPost[]> => {
   if (!uris.length) return [];
-  const qs = new URLSearchParams();
-  for (const u of uris) qs.append('uris', u);
-  const url = `${Constants.BLUESKY_API_ROOT}/xrpc/app.bsky.feed.getPosts?${qs.toString()}`;
-  const ac = new AbortController();
-  const t = setTimeout(() => ac.abort(), DEFAULT_TIMEOUT_MS);
-  let res: Response;
-  try {
-    res = await fetch(url, { signal: ac.signal, headers: { Accept: 'application/json' } });
-  } catch {
-    clearTimeout(t);
-    return [];
-  }
-  clearTimeout(t);
-  if (!res.ok) return [];
-  try {
-    const j = (await res.json()) as { posts?: BlueskyPost[] };
-    return j.posts ?? [];
-  } catch {
-    return [];
-  }
+  const j = await executeBlueskyGetJson<{ posts?: BlueskyPost[] }>(
+    'app.bsky.feed.getPosts',
+    { uris },
+    opts?.credentialKey
+  );
+  return j?.posts ?? [];
 };
 
 export const fetchProfilesByActors = async (
-  actors: string[]
+  actors: string[],
+  opts?: BlueskyFetchOpts
 ): Promise<Map<string, { handle: string; displayName?: string; avatar?: string }>> => {
   const out = new Map<string, { handle: string; displayName?: string; avatar?: string }>();
   if (!actors.length) return out;
-  const qs = new URLSearchParams();
-  for (const a of actors) qs.append('actors', a);
-  const url = `${Constants.BLUESKY_API_ROOT}/xrpc/app.bsky.actor.getProfiles?${qs.toString()}`;
-  const ac = new AbortController();
-  const t = setTimeout(() => ac.abort(), DEFAULT_TIMEOUT_MS);
-  let res: Response;
-  try {
-    res = await fetch(url, { signal: ac.signal, headers: { Accept: 'application/json' } });
-  } catch {
-    clearTimeout(t);
-    return out;
-  }
-  clearTimeout(t);
-  if (!res.ok) return out;
-  try {
-    const j = (await res.json()) as {
-      profiles?: {
-        did: string;
-        handle: string;
-        displayName?: string;
-        avatar?: string;
-      }[];
-    };
-    for (const p of j.profiles ?? []) {
-      out.set(p.did, { handle: p.handle, displayName: p.displayName, avatar: p.avatar });
-    }
-  } catch {
-    /* ignore */
+  const j = await executeBlueskyGetJson<{
+    profiles?: {
+      did: string;
+      handle: string;
+      displayName?: string;
+      avatar?: string;
+    }[];
+  }>('app.bsky.actor.getProfiles', { actors }, opts?.credentialKey);
+  for (const p of j?.profiles ?? []) {
+    out.set(p.did, { handle: p.handle, displayName: p.displayName, avatar: p.avatar });
   }
   return out;
 };
 
 export const fetchActorProfile = async (
-  actor: string
+  actor: string,
+  opts?: BlueskyFetchOpts
 ): Promise<
   { ok: true; data: BlueskyProfileViewDetailed } | { ok: false; status: number; body: string }
 > => {
-  const result = await fetchXrpc<BlueskyProfileViewDetailed>('app.bsky.actor.getProfile', {
-    actor
-  });
+  const result = await executeBlueskyXrpc<BlueskyProfileViewDetailed>(
+    'app.bsky.actor.getProfile',
+    { actor },
+    opts?.credentialKey
+  );
   if (!result.ok) {
     console.log('Bluesky getProfile failed', result.status, result.body?.slice?.(0, 200));
   }
   return result;
 };
 
-export const fetchAuthorFeed = async (params: {
-  actor: string;
-  limit: number;
-  cursor?: string;
-  filter: BlueskyAuthorFeedFilter;
-}): Promise<
+export const fetchAuthorFeed = async (
+  params: {
+    actor: string;
+    limit: number;
+    cursor?: string;
+    filter: BlueskyAuthorFeedFilter;
+  },
+  opts?: BlueskyFetchOpts
+): Promise<
   { ok: true; data: BlueskyAuthorFeedResponse } | { ok: false; status: number; body: string }
 > => {
-  const result = await fetchXrpc<BlueskyAuthorFeedResponse>('app.bsky.feed.getAuthorFeed', {
-    actor: params.actor,
-    limit: params.limit,
-    cursor: params.cursor,
-    filter: params.filter
-  });
+  const result = await executeBlueskyXrpc<BlueskyAuthorFeedResponse>(
+    'app.bsky.feed.getAuthorFeed',
+    {
+      actor: params.actor,
+      limit: params.limit,
+      cursor: params.cursor,
+      filter: params.filter
+    },
+    opts?.credentialKey
+  );
   if (!result.ok) {
     console.log('Bluesky getAuthorFeed failed', result.status, result.body?.slice?.(0, 200));
   }
   return result;
 };
 
-export const fetchActorLikes = async (params: {
-  actor: string;
-  limit: number;
-  cursor?: string;
-}): Promise<
+export const fetchActorLikes = async (
+  params: {
+    actor: string;
+    limit: number;
+    cursor?: string;
+  },
+  opts?: BlueskyFetchOpts
+): Promise<
   { ok: true; data: BlueskyGetActorLikesResponse } | { ok: false; status: number; body: string }
 > => {
-  const result = await fetchXrpc<BlueskyGetActorLikesResponse>('app.bsky.feed.getActorLikes', {
-    actor: params.actor,
-    limit: params.limit,
-    cursor: params.cursor
-  });
+  const result = await executeBlueskyXrpc<BlueskyGetActorLikesResponse>(
+    'app.bsky.feed.getActorLikes',
+    {
+      actor: params.actor,
+      limit: params.limit,
+      cursor: params.cursor
+    },
+    opts?.credentialKey
+  );
   if (!result.ok) {
     console.log('Bluesky getActorLikes failed', result.status, result.body?.slice?.(0, 200));
   }
@@ -176,20 +294,27 @@ export const fetchActorLikes = async (params: {
 };
 
 /** `app.bsky.feed.searchPosts` against public AppView (cursor may be restricted on some hosts). */
-export const fetchSearchPosts = async (params: {
-  q: string;
-  sort: 'latest' | 'top';
-  limit: number;
-  cursor?: string;
-}): Promise<
+export const fetchSearchPosts = async (
+  params: {
+    q: string;
+    sort: 'latest' | 'top';
+    limit: number;
+    cursor?: string;
+  },
+  opts?: BlueskyFetchOpts
+): Promise<
   { ok: true; data: BlueskySearchPostsResponse } | { ok: false; status: number; body: string }
 > => {
-  const result = await fetchXrpc<BlueskySearchPostsResponse>('app.bsky.feed.searchPosts', {
-    q: params.q,
-    sort: params.sort,
-    limit: params.limit,
-    cursor: params.cursor
-  });
+  const result = await executeBlueskyXrpc<BlueskySearchPostsResponse>(
+    'app.bsky.feed.searchPosts',
+    {
+      q: params.q,
+      sort: params.sort,
+      limit: params.limit,
+      cursor: params.cursor
+    },
+    opts?.credentialKey
+  );
   if (!result.ok) {
     console.log('Bluesky searchPosts failed', result.status, result.body?.slice?.(0, 200));
   }
@@ -200,7 +325,8 @@ const GET_PROFILES_MAX_ACTORS = 25;
 
 /** Batch `app.bsky.actor.getProfiles` (max 25 actors per request per lexicon). */
 export const fetchProfilesDetailedBatched = async (
-  actors: string[]
+  actors: string[],
+  opts?: BlueskyFetchOpts
 ): Promise<Map<string, BlueskyProfileViewDetailed>> => {
   const out = new Map<string, BlueskyProfileViewDetailed>();
   if (!actors.length) return out;
@@ -208,103 +334,117 @@ export const fetchProfilesDetailedBatched = async (
 
   for (let i = 0; i < unique.length; i += GET_PROFILES_MAX_ACTORS) {
     const chunk = unique.slice(i, i + GET_PROFILES_MAX_ACTORS);
-    const qs = new URLSearchParams();
-    for (const a of chunk) qs.append('actors', a);
-    const url = `${Constants.BLUESKY_API_ROOT}/xrpc/app.bsky.actor.getProfiles?${qs.toString()}`;
-    const ac = new AbortController();
-    const t = setTimeout(() => ac.abort(), DEFAULT_TIMEOUT_MS);
-    let res: Response;
-    try {
-      res = await fetch(url, { signal: ac.signal, headers: { Accept: 'application/json' } });
-    } catch {
-      clearTimeout(t);
-      continue;
-    }
-    clearTimeout(t);
-    if (!res.ok) continue;
-    try {
-      const j = (await res.json()) as { profiles?: BlueskyProfileViewDetailed[] };
-      for (const p of j.profiles ?? []) {
-        if (p?.did) out.set(p.did, p);
-      }
-    } catch {
-      /* ignore */
+    const j = await executeBlueskyGetJson<{ profiles?: BlueskyProfileViewDetailed[] }>(
+      'app.bsky.actor.getProfiles',
+      { actors: chunk },
+      opts?.credentialKey
+    );
+    for (const p of j?.profiles ?? []) {
+      if (p?.did) out.set(p.did, p);
     }
   }
 
   return out;
 };
 
-export const fetchFollowers = async (params: {
-  actor: string;
-  limit: number;
-  cursor?: string;
-}): Promise<
+export const fetchFollowers = async (
+  params: {
+    actor: string;
+    limit: number;
+    cursor?: string;
+  },
+  opts?: BlueskyFetchOpts
+): Promise<
   { ok: true; data: BlueskyGetFollowersResponse } | { ok: false; status: number; body: string }
 > => {
-  const result = await fetchXrpc<BlueskyGetFollowersResponse>('app.bsky.graph.getFollowers', {
-    actor: params.actor,
-    limit: params.limit,
-    cursor: params.cursor
-  });
+  const result = await executeBlueskyXrpc<BlueskyGetFollowersResponse>(
+    'app.bsky.graph.getFollowers',
+    {
+      actor: params.actor,
+      limit: params.limit,
+      cursor: params.cursor
+    },
+    opts?.credentialKey
+  );
   if (!result.ok) {
     console.log('Bluesky getFollowers failed', result.status, result.body?.slice?.(0, 200));
   }
   return result;
 };
 
-export const fetchFollows = async (params: {
-  actor: string;
-  limit: number;
-  cursor?: string;
-}): Promise<
+export const fetchFollows = async (
+  params: {
+    actor: string;
+    limit: number;
+    cursor?: string;
+  },
+  opts?: BlueskyFetchOpts
+): Promise<
   { ok: true; data: BlueskyGetFollowsResponse } | { ok: false; status: number; body: string }
 > => {
-  const result = await fetchXrpc<BlueskyGetFollowsResponse>('app.bsky.graph.getFollows', {
-    actor: params.actor,
-    limit: params.limit,
-    cursor: params.cursor
-  });
+  const result = await executeBlueskyXrpc<BlueskyGetFollowsResponse>(
+    'app.bsky.graph.getFollows',
+    {
+      actor: params.actor,
+      limit: params.limit,
+      cursor: params.cursor
+    },
+    opts?.credentialKey
+  );
   if (!result.ok) {
     console.log('Bluesky getFollows failed', result.status, result.body?.slice?.(0, 200));
   }
   return result;
 };
 
-export const fetchRepostedBy = async (params: {
-  uri: string;
-  limit: number;
-  cursor?: string;
-  cid?: string;
-}): Promise<
+export const fetchRepostedBy = async (
+  params: {
+    uri: string;
+    limit: number;
+    cursor?: string;
+    cid?: string;
+  },
+  opts?: BlueskyFetchOpts
+): Promise<
   { ok: true; data: BlueskyGetRepostedByResponse } | { ok: false; status: number; body: string }
 > => {
-  const result = await fetchXrpc<BlueskyGetRepostedByResponse>('app.bsky.feed.getRepostedBy', {
-    uri: params.uri,
-    limit: params.limit,
-    cursor: params.cursor,
-    cid: params.cid
-  });
+  const result = await executeBlueskyXrpc<BlueskyGetRepostedByResponse>(
+    'app.bsky.feed.getRepostedBy',
+    {
+      uri: params.uri,
+      limit: params.limit,
+      cursor: params.cursor,
+      cid: params.cid
+    },
+    opts?.credentialKey
+  );
   if (!result.ok) {
     console.log('Bluesky getRepostedBy failed', result.status, result.body?.slice?.(0, 200));
   }
   return result;
 };
 
-export const fetchGetLikes = async (params: {
-  uri: string;
-  limit: number;
-  cursor?: string;
-  cid?: string;
-}): Promise<
+export const fetchGetLikes = async (
+  params: {
+    uri: string;
+    limit: number;
+    cursor?: string;
+    cid?: string;
+  },
+  opts?: BlueskyFetchOpts
+): Promise<
   { ok: true; data: BlueskyGetLikesResponse } | { ok: false; status: number; body: string }
 > => {
-  const result = await fetchXrpc<BlueskyGetLikesResponse>('app.bsky.feed.getLikes', {
-    uri: params.uri,
-    limit: params.limit,
-    cursor: params.cursor,
-    cid: params.cid
-  });
+  const result = await executeBlueskyXrpc<BlueskyGetLikesResponse>(
+    'app.bsky.feed.getLikes',
+    {
+      uri: params.uri,
+      limit: params.limit,
+      cursor: params.cursor,
+      cid: params.cid
+    },
+    opts?.credentialKey
+  );
   if (!result.ok) {
     console.log('Bluesky getLikes failed', result.status, result.body?.slice?.(0, 200));
   }

--- a/src/providers/bluesky/client.ts
+++ b/src/providers/bluesky/client.ts
@@ -153,8 +153,10 @@ async function executeBlueskyXrpc<T>(
       return { ok: true, data: attempt.data };
     }
 
+    // Public already failed with a non-NotFound error (outage, timeout, etc.); do not let a
+    // proxy NotFound override that — it can be a false negative while the record exists.
     if (isNotFoundError(attempt.status, attempt.body)) {
-      return { ok: false, status: attempt.status, body: attempt.body };
+      continue;
     }
 
     if (attempt.status === 401) {
@@ -169,7 +171,7 @@ async function executeBlueskyXrpc<T>(
           return { ok: true, data: attempt.data };
         }
         if (isNotFoundError(attempt.status, attempt.body)) {
-          return { ok: false, status: attempt.status, body: attempt.body };
+          continue;
         }
       }
       continue;

--- a/src/providers/bluesky/client.ts
+++ b/src/providers/bluesky/client.ts
@@ -65,7 +65,6 @@ async function fetchXrpcOnce<T>(
     const headers: Record<string, string> = { Accept: 'application/json' };
     if (options.authorization) headers['Authorization'] = options.authorization;
     const res = await fetch(url, { signal: ac.signal, headers });
-    clearTimeout(t);
     const body = await res.text();
     if (!res.ok) {
       return { ok: false, status: res.status, body };
@@ -76,10 +75,11 @@ async function fetchXrpcOnce<T>(
       return { ok: false, status: 502, body: 'invalid JSON from Bluesky' };
     }
   } catch (e) {
-    clearTimeout(t);
     const msg = e instanceof Error ? e.message : String(e);
     const aborted = e instanceof Error && e.name === 'AbortError';
     return { ok: false, status: 504, body: msg, aborted };
+  } finally {
+    clearTimeout(t);
   }
 }
 
@@ -126,7 +126,16 @@ async function executeBlueskyXrpc<T>(
     return { ok: false, status: first.status, body: first.body };
   }
 
-  await initCredentials(credentialKey);
+  try {
+    await initCredentials(credentialKey);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    console.log(
+      'Bluesky proxy credentials init failed',
+      msg,
+      `(credentialKey length: ${credentialKey.trim().length})`
+    );
+  }
   if (!hasBlueskyProxyAccounts()) {
     return { ok: false, status: first.status, body: first.body };
   }

--- a/src/providers/bluesky/conversation.ts
+++ b/src/providers/bluesky/conversation.ts
@@ -29,14 +29,15 @@ export type BlueskyConversationResult =
 export const fetchBlueskyThread = async (
   post: string,
   author: string,
-  processThread = false
+  processThread = false,
+  credentialKey?: string
 ): Promise<BlueskyThreadResponse | null> => {
   if (!author || !post) {
     return null;
   }
   const uri = atUriForFeedPost(author, post);
   const depth = processThread ? THREAD_FETCH_DEPTH : 1;
-  return fetchPostThread(uri, depth);
+  return fetchPostThread(uri, depth, undefined, { credentialKey });
 };
 
 const followReplyChain = (thread: BlueskyThread): BlueskyPost[] => {
@@ -61,7 +62,8 @@ const followReplyChain = (thread: BlueskyThread): BlueskyPost[] => {
 /** Walk parents + focal + same-author reply continuation (matches `/2/thread` semantics). */
 const collectProcessedThreadPosts = async (
   thread: BlueskyThread,
-  author: string
+  author: string,
+  credentialKey?: string
 ): Promise<BlueskyPost[]> => {
   const bucket: BlueskyPost[] = [];
 
@@ -84,7 +86,7 @@ const collectProcessedThreadPosts = async (
       const nextId = last.uri?.match(/(?<=post\/)([^/]+)/)?.[1] ?? '';
       if (!nextId) break;
 
-      const more = await fetchBlueskyThread(nextId, author, true);
+      const more = await fetchBlueskyThread(nextId, author, true, credentialKey);
       if (!more?.thread) break;
 
       threadPiece = more.thread;
@@ -184,7 +186,8 @@ export const constructBlueskyThread = async (
   c: Context,
   language: string | undefined
 ): Promise<SocialThreadBluesky> => {
-  const _thread = await fetchBlueskyThread(id, author, processThread);
+  const credentialKey = c.env?.CREDENTIAL_KEY;
+  const _thread = await fetchBlueskyThread(id, author, processThread, credentialKey);
 
   if (!_thread?.thread?.post) {
     return {
@@ -197,7 +200,7 @@ export const constructBlueskyThread = async (
 
   const thread = _thread.thread;
   const bucket: BlueskyPost[] = processThread
-    ? await collectProcessedThreadPosts(thread, author)
+    ? await collectProcessedThreadPosts(thread, author, credentialKey)
     : [thread.post];
 
   const consumedPost = (await buildAPIBlueskyPost(c, thread.post, language)) as APIBlueskyStatus;
@@ -224,6 +227,7 @@ export const constructBlueskyConversation = async (
     language?: string;
   }
 ): Promise<BlueskyConversationResult> => {
+  const credentialKey = c.env?.CREDENTIAL_KEY;
   const count = Math.min(100, Math.max(1, Math.floor(options.count)));
   let focalUri: string;
   let mode: 'likes' | 'recency';
@@ -263,8 +267,12 @@ export const constructBlueskyConversation = async (
   }
 
   const raw = isContinuation
-    ? await fetchPostThread(focalUri, CONVERSATION_PAGE_DEPTH, CONVERSATION_PAGE_PARENT_HEIGHT)
-    : await fetchPostThread(focalUri, THREAD_FETCH_DEPTH, THREAD_PARENT_HEIGHT_FIRST_PAGE);
+    ? await fetchPostThread(focalUri, CONVERSATION_PAGE_DEPTH, CONVERSATION_PAGE_PARENT_HEIGHT, {
+        credentialKey
+      })
+    : await fetchPostThread(focalUri, THREAD_FETCH_DEPTH, THREAD_PARENT_HEIGHT_FIRST_PAGE, {
+        credentialKey
+      });
 
   if (!raw?.thread?.post) {
     return {
@@ -285,7 +293,7 @@ export const constructBlueskyConversation = async (
 
   const threadPosts: BlueskyPost[] = isContinuation
     ? [focalNode.post]
-    : await collectProcessedThreadPosts(focalNode, author);
+    : await collectProcessedThreadPosts(focalNode, author, credentialKey);
 
   const directBluesky = collectDirectReplyPosts(focalNode);
   const sorted = sortDirectReplies(directBluesky, mode);

--- a/src/providers/bluesky/processor.ts
+++ b/src/providers/bluesky/processor.ts
@@ -8,7 +8,7 @@ import { translateStatusAI } from '../../helpers/translateAI';
 import { translateStatus } from '../../helpers/translate';
 import { unescapeText } from '../../helpers/utils';
 import { blueskyFacetsToApiFacets } from './facets';
-import { fetchPostsByUris, fetchProfilesByActors } from './client';
+import { type BlueskyFetchOpts, fetchPostsByUris, fetchProfilesByActors } from './client';
 import { blueskyWebPostUrl, didFromAtUri, rkeyFromPostAtUri } from './uris';
 
 const isPossiblySensitive = (labels: ATProtoLabel[] | undefined | null): boolean =>
@@ -127,14 +127,15 @@ const quoteCandidateFromEmbedRecord = (
 };
 
 const resolveReplyingTo = async (
-  status: BlueskyPost
+  status: BlueskyPost,
+  opts?: BlueskyFetchOpts
 ): Promise<{ screen_name: string; status: string } | null> => {
   const parentUri = status.record?.reply?.parent?.uri;
   if (!parentUri) return null;
   const parentRkey = rkeyFromPostAtUri(parentUri);
   const parentDid = didFromAtUri(parentUri);
   if (!parentRkey || !parentDid) return null;
-  const profiles = await fetchProfilesByActors([parentDid]);
+  const profiles = await fetchProfilesByActors([parentDid], opts);
   const handle = profiles.get(parentDid)?.handle ?? parentDid;
   return { screen_name: handle, status: parentRkey };
 };
@@ -265,7 +266,8 @@ const resolveQuote = async (
   c: Context,
   status: BlueskyPost,
   language: string | undefined,
-  quoteDepth: number
+  quoteDepth: number,
+  fetchOpts?: BlueskyFetchOpts
 ): Promise<APIStatus | undefined> => {
   if (quoteDepth > 10) return undefined;
   const embedRecord = status.embed?.record ?? status.embeds?.find(e => e.record)?.record;
@@ -280,7 +282,7 @@ const resolveQuote = async (
   }
 
   if (!post && stubUri) {
-    const fetched = await fetchPostsByUris([stubUri]);
+    const fetched = await fetchPostsByUris([stubUri], fetchOpts);
     post = fetched[0] ?? null;
   }
 
@@ -299,6 +301,7 @@ export const buildAPIBlueskyPost = async (
   language: string | undefined,
   quoteDepth = 0
 ): Promise<APIStatus> => {
+  const bskyFetchOpts: BlueskyFetchOpts = { credentialKey: c.env?.CREDENTIAL_KEY };
   const rkey = rkeyFromPostAtUri(status.uri) ?? status.cid;
   const record = status.record ?? status.value;
   const rawText = record?.text ?? '';
@@ -331,7 +334,7 @@ export const buildAPIBlueskyPost = async (
     media: {},
     lang: record?.langs?.[0] ?? null,
     possibly_sensitive: isPossiblySensitive(status.labels),
-    replying_to: await resolveReplyingTo(status),
+    replying_to: await resolveReplyingTo(status, bskyFetchOpts),
     source: 'Bluesky Social',
     embed_card: 'tweet',
     provider: DataProvider.Bluesky
@@ -339,7 +342,7 @@ export const buildAPIBlueskyPost = async (
 
   await applyEmbedsToStatus(apiStatus, status);
 
-  const quote = await resolveQuote(c, status, language, quoteDepth);
+  const quote = await resolveQuote(c, status, language, quoteDepth, bskyFetchOpts);
   if (quote) {
     apiStatus.quote = quote;
     if (quote.embed_card && quote.embed_card !== 'tweet') {

--- a/src/providers/bluesky/profile.ts
+++ b/src/providers/bluesky/profile.ts
@@ -53,9 +53,9 @@ export const blueskyProfileToApiUser = (profile: BlueskyProfileViewDetailed): AP
 
 export const blueskyUserProfileAPI = async (
   actor: string,
-  _c: Context
+  c: Context
 ): Promise<UserAPIResponse> => {
-  const result = await fetchActorProfile(actor);
+  const result = await fetchActorProfile(actor, { credentialKey: c.env?.CREDENTIAL_KEY });
   if (!result.ok) {
     if (result.status === 400 || result.status === 404) {
       return { code: 404, message: 'User not found' };

--- a/src/providers/bluesky/profileFollowers.ts
+++ b/src/providers/bluesky/profileFollowers.ts
@@ -62,13 +62,17 @@ export const blueskyProfileViewToApiUser = (view: BlueskyProfileView): APIUser =
 export const blueskyProfileFollowersAPI = async (
   actor: string,
   options: { count: number; cursor: string | null },
-  _c: Context
+  c: Context
 ): Promise<APIProfileRelationshipList> => {
-  const result = await fetchFollowers({
-    actor,
-    limit: options.count,
-    cursor: options.cursor ?? undefined
-  });
+  const fetchOpts = { credentialKey: c.env?.CREDENTIAL_KEY };
+  const result = await fetchFollowers(
+    {
+      actor,
+      limit: options.count,
+      cursor: options.cursor ?? undefined
+    },
+    fetchOpts
+  );
 
   if (!result.ok) {
     if (result.status === 400 || result.status === 404) {
@@ -81,7 +85,7 @@ export const blueskyProfileFollowersAPI = async (
   const nextCursor = result.data.cursor ?? null;
 
   const dids = followers.map(f => f.did);
-  const detailedByDid = await fetchProfilesDetailedBatched(dids);
+  const detailedByDid = await fetchProfilesDetailedBatched(dids, fetchOpts);
 
   const results: APIUser[] = followers.map(f => {
     const detailed = detailedByDid.get(f.did);
@@ -101,13 +105,17 @@ export const blueskyProfileFollowersAPI = async (
 export const blueskyProfileFollowingAPI = async (
   actor: string,
   options: { count: number; cursor: string | null },
-  _c: Context
+  c: Context
 ): Promise<APIProfileRelationshipList> => {
-  const result = await fetchFollows({
-    actor,
-    limit: options.count,
-    cursor: options.cursor ?? undefined
-  });
+  const fetchOpts = { credentialKey: c.env?.CREDENTIAL_KEY };
+  const result = await fetchFollows(
+    {
+      actor,
+      limit: options.count,
+      cursor: options.cursor ?? undefined
+    },
+    fetchOpts
+  );
 
   if (!result.ok) {
     if (result.status === 400 || result.status === 404) {
@@ -120,7 +128,7 @@ export const blueskyProfileFollowingAPI = async (
   const nextCursor = result.data.cursor ?? null;
 
   const dids = follows.map(f => f.did);
-  const detailedByDid = await fetchProfilesDetailedBatched(dids);
+  const detailedByDid = await fetchProfilesDetailedBatched(dids, fetchOpts);
 
   const results: APIUser[] = follows.map(f => {
     const detailed = detailedByDid.get(f.did);

--- a/src/providers/bluesky/profileStatuses.ts
+++ b/src/providers/bluesky/profileStatuses.ts
@@ -68,12 +68,15 @@ async function blueskyAuthorFeedSearchPage(
   },
   c: Context
 ): Promise<APISearchResultsBluesky> {
-  const result = await fetchAuthorFeed({
-    actor,
-    limit: options.count,
-    cursor: options.cursor ?? undefined,
-    filter: options.filter
-  });
+  const result = await fetchAuthorFeed(
+    {
+      actor,
+      limit: options.count,
+      cursor: options.cursor ?? undefined,
+      filter: options.filter
+    },
+    { credentialKey: c.env?.CREDENTIAL_KEY }
+  );
 
   if (!result.ok) {
     if (result.status === 400 || result.status === 404) {
@@ -135,11 +138,14 @@ export const blueskyProfileLikesAPI = async (
   options: { count: number; cursor: string | null; language?: string },
   c: Context
 ): Promise<APISearchResultsBluesky> => {
-  const result = await fetchActorLikes({
-    actor,
-    limit: options.count,
-    cursor: options.cursor ?? undefined
-  });
+  const result = await fetchActorLikes(
+    {
+      actor,
+      limit: options.count,
+      cursor: options.cursor ?? undefined
+    },
+    { credentialKey: c.env?.CREDENTIAL_KEY }
+  );
 
   if (!result.ok) {
     if (result.status === 400 || result.status === 404) {

--- a/src/providers/bluesky/search.ts
+++ b/src/providers/bluesky/search.ts
@@ -55,12 +55,15 @@ export const blueskySearchAPI = async (
   }
 ): Promise<APISearchResultsBluesky> => {
   const sort = feedToSort(options.feed);
-  const result = await fetchSearchPosts({
-    q: options.q,
-    sort,
-    limit: options.count,
-    cursor: options.cursor ?? undefined
-  });
+  const result = await fetchSearchPosts(
+    {
+      q: options.q,
+      sort,
+      limit: options.count,
+      cursor: options.cursor ?? undefined
+    },
+    { credentialKey: c.env?.CREDENTIAL_KEY }
+  );
 
   if (!result.ok) {
     if (result.status === 400 || result.status === 404) {

--- a/src/providers/bluesky/session.ts
+++ b/src/providers/bluesky/session.ts
@@ -48,7 +48,6 @@ async function createSession(cred: BlueskyProxyCredentials): Promise<CachedBlues
       headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
       body: JSON.stringify({ identifier: cred.identifier, password: cred.appPassword })
     });
-    clearTimeout(t);
     const text = await res.text();
     if (!res.ok) return null;
     const j = JSON.parse(text) as { accessJwt?: string; refreshJwt?: string };
@@ -56,8 +55,9 @@ async function createSession(cred: BlueskyProxyCredentials): Promise<CachedBlues
     const accessExpiresAtMs = parseJwtExpMs(j.accessJwt) ?? Date.now() + 120_000;
     return { accessJwt: j.accessJwt, refreshJwt: j.refreshJwt, accessExpiresAtMs };
   } catch {
-    clearTimeout(t);
     return null;
+  } finally {
+    clearTimeout(t);
   }
 }
 
@@ -78,7 +78,6 @@ async function refreshSession(
         'Accept': 'application/json'
       }
     });
-    clearTimeout(t);
     const text = await res.text();
     if (!res.ok) return null;
     const j = JSON.parse(text) as { accessJwt?: string; refreshJwt?: string };
@@ -86,8 +85,9 @@ async function refreshSession(
     const accessExpiresAtMs = parseJwtExpMs(j.accessJwt) ?? Date.now() + 120_000;
     return { accessJwt: j.accessJwt, refreshJwt: j.refreshJwt, accessExpiresAtMs };
   } catch {
-    clearTimeout(t);
     return null;
+  } finally {
+    clearTimeout(t);
   }
 }
 

--- a/src/providers/bluesky/session.ts
+++ b/src/providers/bluesky/session.ts
@@ -1,0 +1,131 @@
+import type { BlueskyProxyCredentials } from '../twitter/proxy/types';
+
+const SESSION_FETCH_TIMEOUT_MS = 8_000;
+
+export type CachedBlueskySession = {
+  accessJwt: string;
+  refreshJwt: string;
+  accessExpiresAtMs: number;
+};
+
+const sessionCache = new Map<string, CachedBlueskySession>();
+const sessionInFlight = new Map<string, Promise<CachedBlueskySession | null>>();
+
+function normalizeServiceBase(service: string): string {
+  return service.replace(/\/$/, '');
+}
+
+export function blueskyProxyCacheKey(cred: BlueskyProxyCredentials): string {
+  return `${normalizeServiceBase(cred.service)}\0${cred.identifier}`;
+}
+
+function parseJwtExpMs(jwt: string): number | null {
+  try {
+    const parts = jwt.split('.');
+    if (parts.length < 2) return null;
+    const payload = parts[1] ?? '';
+    const pad = '='.repeat((4 - (payload.length % 4)) % 4);
+    const b64 = (payload + pad).replace(/-/g, '+').replace(/_/g, '/');
+    const json = JSON.parse(atob(b64)) as { exp?: number };
+    return typeof json.exp === 'number' ? json.exp * 1000 : null;
+  } catch {
+    return null;
+  }
+}
+
+export function invalidateBlueskySession(cred: BlueskyProxyCredentials): void {
+  sessionCache.delete(blueskyProxyCacheKey(cred));
+}
+
+async function createSession(cred: BlueskyProxyCredentials): Promise<CachedBlueskySession | null> {
+  const base = normalizeServiceBase(cred.service);
+  const ac = new AbortController();
+  const t = setTimeout(() => ac.abort(), SESSION_FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(`${base}/xrpc/com.atproto.server.createSession`, {
+      method: 'POST',
+      signal: ac.signal,
+      headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
+      body: JSON.stringify({ identifier: cred.identifier, password: cred.appPassword })
+    });
+    clearTimeout(t);
+    const text = await res.text();
+    if (!res.ok) return null;
+    const j = JSON.parse(text) as { accessJwt?: string; refreshJwt?: string };
+    if (!j.accessJwt || !j.refreshJwt) return null;
+    const accessExpiresAtMs = parseJwtExpMs(j.accessJwt) ?? Date.now() + 120_000;
+    return { accessJwt: j.accessJwt, refreshJwt: j.refreshJwt, accessExpiresAtMs };
+  } catch {
+    clearTimeout(t);
+    return null;
+  }
+}
+
+async function refreshSession(
+  cred: BlueskyProxyCredentials,
+  refreshJwt: string
+): Promise<CachedBlueskySession | null> {
+  const base = normalizeServiceBase(cred.service);
+  const ac = new AbortController();
+  const t = setTimeout(() => ac.abort(), SESSION_FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(`${base}/xrpc/com.atproto.server.refreshSession`, {
+      method: 'POST',
+      signal: ac.signal,
+      headers: {
+        'Authorization': `Bearer ${refreshJwt}`,
+        'Content-Type': 'application/json',
+        'Accept': 'application/json'
+      }
+    });
+    clearTimeout(t);
+    const text = await res.text();
+    if (!res.ok) return null;
+    const j = JSON.parse(text) as { accessJwt?: string; refreshJwt?: string };
+    if (!j.accessJwt || !j.refreshJwt) return null;
+    const accessExpiresAtMs = parseJwtExpMs(j.accessJwt) ?? Date.now() + 120_000;
+    return { accessJwt: j.accessJwt, refreshJwt: j.refreshJwt, accessExpiresAtMs };
+  } catch {
+    clearTimeout(t);
+    return null;
+  }
+}
+
+/**
+ * Returns a valid access JWT for the proxy account, using cache + refresh + createSession.
+ */
+export async function getBlueskyAccessJwt(cred: BlueskyProxyCredentials): Promise<string | null> {
+  const key = blueskyProxyCacheKey(cred);
+  const cached = sessionCache.get(key);
+  if (cached && cached.accessExpiresAtMs > Date.now() + 30_000) {
+    return cached.accessJwt;
+  }
+
+  const pending = sessionInFlight.get(key);
+  if (pending) {
+    const s = await pending;
+    return s?.accessJwt ?? null;
+  }
+
+  const promise = (async (): Promise<CachedBlueskySession | null> => {
+    try {
+      const cur = sessionCache.get(key);
+      if (cur?.refreshJwt) {
+        const refreshed = await refreshSession(cred, cur.refreshJwt);
+        if (refreshed) {
+          sessionCache.set(key, refreshed);
+          return refreshed;
+        }
+      }
+      const created = await createSession(cred);
+      if (created) sessionCache.set(key, created);
+      return created;
+    } finally {
+      sessionInFlight.delete(key);
+    }
+  })();
+
+  sessionInFlight.set(key, promise);
+  const result = await promise;
+  return result?.accessJwt ?? null;
+}

--- a/src/providers/bluesky/statusLikes.ts
+++ b/src/providers/bluesky/statusLikes.ts
@@ -21,14 +21,18 @@ export const blueskyStatusLikesAPI = async (
   handle: string,
   rkey: string,
   options: { count: number; cursor: string | null },
-  _c: Context
+  c: Context
 ): Promise<APIUserListResults> => {
+  const fetchOpts = { credentialKey: c.env?.CREDENTIAL_KEY };
   const uri = atUriForFeedPost(handle, rkey);
-  const result = await fetchGetLikes({
-    uri,
-    limit: options.count,
-    cursor: options.cursor ?? undefined
-  });
+  const result = await fetchGetLikes(
+    {
+      uri,
+      limit: options.count,
+      cursor: options.cursor ?? undefined
+    },
+    fetchOpts
+  );
 
   if (!result.ok) {
     if (result.status === 400 || result.status === 404) {
@@ -41,7 +45,7 @@ export const blueskyStatusLikesAPI = async (
   const nextCursor = result.data.cursor ?? null;
 
   const dids = likes.map(l => l.actor.did);
-  const detailedByDid = await fetchProfilesDetailedBatched(dids);
+  const detailedByDid = await fetchProfilesDetailedBatched(dids, fetchOpts);
 
   const results = likes.map(l => {
     const detailed = detailedByDid.get(l.actor.did);

--- a/src/providers/bluesky/statusReposts.ts
+++ b/src/providers/bluesky/statusReposts.ts
@@ -21,14 +21,18 @@ export const blueskyStatusRepostsAPI = async (
   handle: string,
   rkey: string,
   options: { count: number; cursor: string | null },
-  _c: Context
+  c: Context
 ): Promise<APIUserListResults> => {
+  const fetchOpts = { credentialKey: c.env?.CREDENTIAL_KEY };
   const uri = atUriForFeedPost(handle, rkey);
-  const result = await fetchRepostedBy({
-    uri,
-    limit: options.count,
-    cursor: options.cursor ?? undefined
-  });
+  const result = await fetchRepostedBy(
+    {
+      uri,
+      limit: options.count,
+      cursor: options.cursor ?? undefined
+    },
+    fetchOpts
+  );
 
   if (!result.ok) {
     if (result.status === 400 || result.status === 404) {
@@ -41,7 +45,7 @@ export const blueskyStatusRepostsAPI = async (
   const nextCursor = result.data.cursor ?? null;
 
   const dids = repostedBy.map(p => p.did);
-  const detailedByDid = await fetchProfilesDetailedBatched(dids);
+  const detailedByDid = await fetchProfilesDetailedBatched(dids, fetchOpts);
 
   const results = repostedBy.map(p => {
     const detailed = detailedByDid.get(p.did);

--- a/src/providers/twitter/proxy/credentials.ts
+++ b/src/providers/twitter/proxy/credentials.ts
@@ -1,4 +1,4 @@
-import type { CredentialStore, TwitterCredentials } from './types';
+import type { BlueskyProxyCredentials, CredentialStore, TwitterCredentials } from './types';
 
 let credentialStore: CredentialStore | null = null;
 let initOnce: Promise<void> | null = null;
@@ -78,14 +78,32 @@ export async function initCredentials(credentialKey: string | undefined): Promis
 }
 
 export function getRandomTwitterAccount(): TwitterCredentials {
-  if (!credentialStore?.twitter?.accounts?.length) {
+  const accounts = credentialStore?.twitter?.accounts;
+  if (!accounts?.length) {
     throw new Error('Twitter credentials not initialized or empty');
   }
-  const accounts = credentialStore.twitter.accounts;
   const randomIndex = Math.floor(Math.random() * accounts.length);
   return accounts[randomIndex];
 }
 
 export function hasDecryptedCredentials(): boolean {
   return credentialStore !== null && (credentialStore.twitter?.accounts?.length ?? 0) > 0;
+}
+
+export function hasBlueskyProxyAccounts(): boolean {
+  return (credentialStore?.bluesky?.accounts?.length ?? 0) > 0;
+}
+
+/** Fisher–Yates shuffle copy for spreading load across PDS proxy accounts. */
+export function getShuffledBlueskyAccounts(): BlueskyProxyCredentials[] {
+  const acc = credentialStore?.bluesky?.accounts ?? [];
+  if (!acc.length) return [];
+  const copy = [...acc];
+  for (let i = copy.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    const t = copy[i]!;
+    copy[i] = copy[j]!;
+    copy[j] = t;
+  }
+  return copy;
 }

--- a/src/providers/twitter/proxy/types.ts
+++ b/src/providers/twitter/proxy/types.ts
@@ -4,10 +4,18 @@ export type TwitterCredentials = {
   username: string;
 };
 
+/** Bluesky proxy: app password auth against the account PDS (entryway or *.host.bsky.network). */
+export type BlueskyProxyCredentials = {
+  identifier: string;
+  appPassword: string;
+  service: string;
+};
+
 /** Per-provider credential buckets; extend with instagram, etc. */
 export type CredentialStore = {
-  twitter: { accounts: TwitterCredentials[] };
-} & Record<string, { accounts: unknown[] }>;
+  twitter?: { accounts: TwitterCredentials[] };
+  bluesky?: { accounts: BlueskyProxyCredentials[] };
+};
 
 export type ErrorResponse = {
   error: string;

--- a/test/bluesky.client-upstream.test.ts
+++ b/test/bluesky.client-upstream.test.ts
@@ -27,7 +27,7 @@ vi.mock('../src/providers/twitter/proxy/credentials', async importOriginal => {
 
 vi.mock('../src/providers/bluesky/session', () => sessionMocks);
 
-import { fetchPostThread } from '../src/providers/bluesky/client';
+import { fetchActorProfile, fetchPostThread } from '../src/providers/bluesky/client';
 
 beforeEach(() => {
   credMocks.initCredentials.mockClear();
@@ -96,4 +96,28 @@ test('fetchPostThread does not call proxy when public returns NotFound', async (
   expect(calls.length).toBe(1);
   expect(calls[0]).toContain('public.api.bsky.app');
   expect(credMocks.initCredentials).not.toHaveBeenCalled();
+});
+
+test('fetchActorProfile preserves public outage when proxy returns NotFound', async () => {
+  vi.spyOn(globalThis, 'fetch').mockImplementation(async (input: RequestInfo) => {
+    const url = typeof input === 'string' ? input : input.url;
+    if (url.includes('public.api.bsky.app')) {
+      return new Response('upstream overloaded', { status: 503 });
+    }
+    if (url.includes('pds.example')) {
+      return new Response(JSON.stringify({ error: 'NotFound', message: 'Record not found' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+    throw new Error(`Unexpected fetch: ${url}`);
+  });
+
+  const result = await fetchActorProfile('did:plc:test', { credentialKey: 'dummy-key' });
+
+  expect(result.ok).toBe(false);
+  if (!result.ok) {
+    expect(result.status).toBe(503);
+    expect(result.body).toContain('overloaded');
+  }
 });

--- a/test/bluesky.client-upstream.test.ts
+++ b/test/bluesky.client-upstream.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+
+const credMocks = vi.hoisted(() => ({
+  initCredentials: vi.fn().mockResolvedValue(undefined),
+  hasBundledEncryptedCredentials: vi.fn(() => true),
+  hasBlueskyProxyAccounts: vi.fn(() => true),
+  getShuffledBlueskyAccounts: vi.fn(() => [
+    { identifier: 'u.test', appPassword: 'x', service: 'https://pds.example' }
+  ])
+}));
+
+const sessionMocks = vi.hoisted(() => ({
+  getBlueskyAccessJwt: vi.fn().mockResolvedValue('jwt-test'),
+  invalidateBlueskySession: vi.fn()
+}));
+
+vi.mock('../src/providers/twitter/proxy/credentials', async importOriginal => {
+  const actual = await importOriginal<typeof import('../src/providers/twitter/proxy/credentials')>();
+  return {
+    ...actual,
+    initCredentials: credMocks.initCredentials,
+    hasBundledEncryptedCredentials: credMocks.hasBundledEncryptedCredentials,
+    hasBlueskyProxyAccounts: credMocks.hasBlueskyProxyAccounts,
+    getShuffledBlueskyAccounts: credMocks.getShuffledBlueskyAccounts
+  };
+});
+
+vi.mock('../src/providers/bluesky/session', () => sessionMocks);
+
+import { fetchPostThread } from '../src/providers/bluesky/client';
+
+beforeEach(() => {
+  credMocks.initCredentials.mockClear();
+  sessionMocks.getBlueskyAccessJwt.mockClear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test('fetchPostThread uses PDS proxy when public API returns 503', async () => {
+  const calls: { url: string; authorization?: string }[] = [];
+  vi.spyOn(globalThis, 'fetch').mockImplementation(async (input: RequestInfo, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.url;
+    const headers = init?.headers;
+    let authorization: string | undefined;
+    if (headers && typeof headers === 'object' && !Array.isArray(headers) && !(headers instanceof Headers)) {
+      authorization = (headers as Record<string, string>)['Authorization'];
+    } else if (headers instanceof Headers) {
+      authorization = headers.get('Authorization') ?? undefined;
+    }
+    calls.push({ url, authorization });
+
+    if (url.includes('public.api.bsky.app')) {
+      return new Response('unavailable', { status: 503 });
+    }
+    if (url.includes('pds.example')) {
+      expect(authorization).toBe('Bearer jwt-test');
+      return new Response(JSON.stringify({ thread: { $type: 'test', post: null } }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+    throw new Error(`Unexpected fetch: ${url}`);
+  });
+
+  const result = await fetchPostThread('at://did:plc:x/app.bsky.feed.post/rkey', 1, undefined, {
+    credentialKey: 'dummy-key'
+  });
+
+  expect(result).not.toBeNull();
+  expect(calls.some(c => c.url.includes('public.api.bsky.app'))).toBe(true);
+  expect(calls.some(c => c.url.includes('pds.example'))).toBe(true);
+  expect(credMocks.initCredentials).toHaveBeenCalledWith('dummy-key');
+});
+
+test('fetchPostThread does not call proxy when public returns NotFound', async () => {
+  const calls: string[] = [];
+  vi.spyOn(globalThis, 'fetch').mockImplementation(async (input: RequestInfo) => {
+    const url = typeof input === 'string' ? input : input.url;
+    calls.push(url);
+    if (url.includes('public.api.bsky.app')) {
+      return new Response(JSON.stringify({ error: 'NotFound', message: 'Not found' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+    throw new Error(`Unexpected fetch: ${url}`);
+  });
+
+  const result = await fetchPostThread('at://did:plc:x/app.bsky.feed.post/missing', 1, undefined, {
+    credentialKey: 'dummy-key'
+  });
+
+  expect(result).toBeNull();
+  expect(calls.length).toBe(1);
+  expect(calls[0]).toContain('public.api.bsky.app');
+  expect(credMocks.initCredentials).not.toHaveBeenCalled();
+});

--- a/tools/credential-tools.mjs
+++ b/tools/credential-tools.mjs
@@ -65,11 +65,33 @@ function encrypt() {
 
   const plaintext = readFileSync(PLAINTEXT_PATH, 'utf-8');
   const parsed = JSON.parse(plaintext);
-  if (!parsed?.twitter?.accounts || !Array.isArray(parsed.twitter.accounts)) {
+  const hasTwitter =
+    Array.isArray(parsed?.twitter?.accounts) && parsed.twitter.accounts.length > 0;
+  const hasBluesky =
+    Array.isArray(parsed?.bluesky?.accounts) && parsed.bluesky.accounts.length > 0;
+  if (!hasTwitter && !hasBluesky) {
     console.error(
-      'credentials.json must use the multi-provider shape, e.g. { "twitter": { "accounts": [...] } } (see credentials.example.json).'
+      'credentials.json must include a non-empty twitter.accounts and/or bluesky.accounts array (see credentials.example.json).'
     );
     process.exit(1);
+  }
+  if (hasBluesky) {
+    const bskyFields = ['identifier', 'appPassword', 'service'];
+    for (let i = 0; i < parsed.bluesky.accounts.length; i++) {
+      const cred = parsed.bluesky.accounts[i];
+      const id = `bluesky.accounts[${i}]`;
+      if (cred === null || typeof cred !== 'object' || Array.isArray(cred)) {
+        console.error(`${id}: each account must be a plain object`);
+        process.exit(1);
+      }
+      for (const field of bskyFields) {
+        const v = cred[field];
+        if (typeof v !== 'string' || v.length === 0) {
+          console.error(`${id}: "${field}" must be a non-empty string`);
+          process.exit(1);
+        }
+      }
+    }
   }
 
   let keyB64url;

--- a/tools/stripcredentials.mjs
+++ b/tools/stripcredentials.mjs
@@ -1,6 +1,6 @@
 /**
  * Strip sensitive fields from credentials.complete.json → credentials.json
- * Output shape: { "twitter": { "accounts": [{ username, authToken, csrfToken }] } }
+ * Output shape: { "twitter": { "accounts": [...] }, "bluesky": { "accounts": [...] } }
  *
  * Accepts complete file as either:
  *   - { "twitter": { "accounts": [...] } }  (preferred)
@@ -15,65 +15,99 @@ const completePath = join(repoRoot, 'credentials.complete.json');
 const outPath = join(repoRoot, 'credentials.json');
 
 const raw = JSON.parse(fs.readFileSync(completePath, 'utf8'));
-const accounts = Array.isArray(raw.twitter?.accounts)
+const twitterAccounts = Array.isArray(raw.twitter?.accounts)
   ? raw.twitter.accounts
   : Array.isArray(raw.accounts)
     ? raw.accounts
     : null;
 
-if (!Array.isArray(accounts) || accounts.length === 0) {
+const blueskyAccounts = Array.isArray(raw.bluesky?.accounts) ? raw.bluesky.accounts : null;
+
+if (
+  (!Array.isArray(twitterAccounts) || twitterAccounts.length === 0) &&
+  (!Array.isArray(blueskyAccounts) || blueskyAccounts.length === 0)
+) {
   console.error(
-    'credentials.complete.json must have twitter.accounts or legacy top-level accounts as a non-empty array'
+    'credentials.complete.json must have twitter.accounts (or legacy accounts), and/or bluesky.accounts, as non-empty arrays'
   );
   process.exit(1);
 }
 
-const requiredStringFields = ['username', 'authToken', 'csrfToken'];
+const out = {};
 
-for (let i = 0; i < accounts.length; i++) {
-  const cred = accounts[i];
-  const id =
-    cred != null &&
-    typeof cred === 'object' &&
-    !Array.isArray(cred) &&
-    typeof cred.username === 'string' &&
-    cred.username.length > 0
-      ? `accounts[${i}] (username: ${JSON.stringify(cred.username)})`
-      : `accounts[${i}]`;
+if (Array.isArray(twitterAccounts) && twitterAccounts.length > 0) {
+  const requiredStringFields = ['username', 'authToken', 'csrfToken'];
 
-  if (cred === null || typeof cred !== 'object' || Array.isArray(cred)) {
-    console.error(`${id}: each account must be a plain object`);
-    process.exit(1);
+  for (let i = 0; i < twitterAccounts.length; i++) {
+    const cred = twitterAccounts[i];
+    const id =
+      cred != null &&
+      typeof cred === 'object' &&
+      !Array.isArray(cred) &&
+      typeof cred.username === 'string' &&
+      cred.username.length > 0
+        ? `twitter.accounts[${i}] (username: ${JSON.stringify(cred.username)})`
+        : `twitter.accounts[${i}]`;
+
+    if (cred === null || typeof cred !== 'object' || Array.isArray(cred)) {
+      console.error(`${id}: each account must be a plain object`);
+      process.exit(1);
+    }
+
+    for (const field of requiredStringFields) {
+      const v = cred[field];
+      if (v === undefined || v === null) {
+        console.error(`${id}: missing required field "${field}"`);
+        process.exit(1);
+      }
+      if (typeof v !== 'string') {
+        console.error(`${id}: "${field}" must be a non-empty string, got ${typeof v}`);
+        process.exit(1);
+      }
+      if (v.length === 0) {
+        console.error(`${id}: "${field}" must be non-empty`);
+        process.exit(1);
+      }
+    }
   }
 
-  for (const field of requiredStringFields) {
-    const v = cred[field];
-    if (v === undefined || v === null) {
-      console.error(`${id}: missing required field "${field}"`);
-      process.exit(1);
-    }
-    if (typeof v !== 'string') {
-      console.error(
-        `${id}: "${field}" must be a non-empty string, got ${typeof v}`
-      );
-      process.exit(1);
-    }
-    if (v.length === 0) {
-      console.error(`${id}: "${field}" must be non-empty`);
-      process.exit(1);
-    }
-  }
+  out.twitter = {
+    accounts: twitterAccounts.map(cred => ({
+      username: cred.username,
+      authToken: cred.authToken,
+      csrfToken: cred.csrfToken
+    }))
+  };
 }
 
-const stripped = accounts.map(cred => ({
-  username: cred.username,
-  authToken: cred.authToken,
-  csrfToken: cred.csrfToken
-}));
-
-const out = { ...raw };
-delete out.accounts;
-out.twitter = { accounts: stripped };
+if (Array.isArray(blueskyAccounts) && blueskyAccounts.length > 0) {
+  const bskyFields = ['identifier', 'appPassword', 'service'];
+  for (let i = 0; i < blueskyAccounts.length; i++) {
+    const cred = blueskyAccounts[i];
+    const id = `bluesky.accounts[${i}]`;
+    if (cred === null || typeof cred !== 'object' || Array.isArray(cred)) {
+      console.error(`${id}: each account must be a plain object`);
+      process.exit(1);
+    }
+    for (const field of bskyFields) {
+      const v = cred[field];
+      if (typeof v !== 'string' || v.length === 0) {
+        console.error(`${id}: "${field}" must be a non-empty string`);
+        process.exit(1);
+      }
+    }
+  }
+  out.bluesky = {
+    accounts: blueskyAccounts.map(cred => ({
+      identifier: cred.identifier,
+      appPassword: cred.appPassword,
+      service: cred.service.replace(/\/$/, '')
+    }))
+  };
+}
 
 fs.writeFileSync(outPath, JSON.stringify(out, null, 2) + '\n', 'utf8');
-console.log(`Wrote ${outPath} (${stripped.length} twitter account(s))`);
+const parts = [];
+if (out.twitter) parts.push(`${out.twitter.accounts.length} twitter account(s)`);
+if (out.bluesky) parts.push(`${out.bluesky.accounts.length} bluesky account(s)`);
+console.log(`Wrote ${outPath} (${parts.join(', ')})`);


### PR DESCRIPTION
Improve Bluesky API resiliency in response to a major Bluesky outage that left the public API completely inoperable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Bluesky proxy account support, credential-backed requests across Bluesky endpoints, and a new example Bluesky credentials entry; runtime-derived credential key is honored.
  * Added session caching and JWT management for Bluesky proxy tokens.

* **Bug Fixes**
  * Improved upstream request handling with per-attempt timeouts, clearer error outcomes, and smarter retry/fallback to proxy accounts.

* **Tests**
  * Added tests covering public vs proxy fallback and credential usage.

* **Tools**
  * Updated credential validation and stripping utilities to support Bluesky account formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->