### PR TITLE
feat: group threads in timeline feeds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,29 +1,17 @@
 # AGENTS.md
 
-This is the repository for FxEmbed, the home of FxTwitter, FixupX, and FxBluesky. FxEmbed generates rich embeds for social media posts (X/Twitter, Bluesky, TikTok) for chat platforms like Discord and Telegram. There is a public API provided for X/Twitter, Bluesky and such, the modern v2 API generates an OpenAPI spec. Typically deployed using Cloudflare Workers, this TypeScript app uses Hono for routing, i18next localization, zod API validation. 
+This is the repository for FxEmbed, the home of FxTwitter, FixupX, and FxBluesky. FxEmbed generates rich embeds for social media posts (X/Twitter, Bluesky, TikTok) for chat platforms like Discord and Telegram. There is a public API provided for X/Twitter, Bluesky and such, the modern v2 API generates an OpenAPI spec. Typically deployed using Cloudflare Workers, this TypeScript app uses Hono for routing, i18next localization, zod API validation.
 
 ## Environment variables
 
 Environment variables are generally set in .env, not in Wrangler, except for certain secrets such as CREDENTIAL_KEY. When adding an environment variable, you generally have to add them in the following places for them to be included correctly during a build:
+
 - `.env.example` (for documentation)
 - `esbuild.config.mjs` (so it's passed to the worker during build)
 - `vitest.config.mts` (for tests)
 - `.github/workflows/deploy.yml` (So GitHub Actions variables/secrets are given to it during deployment)
 - `src/types/env.d.ts` (for type documentation)
 - `src/constants.ts` (We typically load all environment variables under the Constants object)
-
-## Formatting
-
-We use Prettier for formatting. To format the code, run `npm run prettier`.
-
-## Linting
-
-We use ESLint for linting. To lint the code, run `npm run lint:eslint`.
-
-## Testing
-
-We use Vitest for testing. To test the full suite of code, run `npm test`.
-
 ## Cursor Cloud specific instructions
 
 ### Prerequisites
@@ -33,14 +21,14 @@ We use Vitest for testing. To test the full suite of code, run `npm test`.
 
 ### Key commands
 
-| Task | Command |
-|---|---|
-| Install deps | `npm install` |
-| Lint | `npm run lint:eslint` |
-| Format | `npm run prettier` |
-| Build (local) | `npm run build-local` |
-| Test | `npm run test` |
-| Dev server | `npx wrangler dev --local` (serves on `http://localhost:8787`) |
+| Task          | Command                                                        |
+| ------------- | -------------------------------------------------------------- |
+| Install deps  | `npm install`                                                  |
+| Lint          | `npm run lint:eslint`                                          |
+| Format        | `npm run prettier`                                             |
+| Build (local) | `npm run build-local`                                          |
+| Test          | `npm run test`                                                 |
+| Dev server    | `npx wrangler dev --local` (serves on `http://localhost:8787`) |
 
 ### Dev server testing notes
 

--- a/src/helpers/media.ts
+++ b/src/helpers/media.ts
@@ -141,7 +141,7 @@ export const processMedia = (c: Context, media: TweetMedia): APIPhoto | APIVideo
       type: media.type === 'animated_gif' ? 'gif' : 'video',
       formats: formats,
       publisher: media.additional_media_info?.source_user
-        ? convertToApiUser(media.additional_media_info.source_user.user_results?.result)
+        ? convertToApiUser(media.additional_media_info.source_user.user_results?.result, false)
         : null
     };
   }

--- a/src/providers/bluesky/processor.ts
+++ b/src/providers/bluesky/processor.ts
@@ -33,7 +33,8 @@ const apiUserFromAuthor = (author: BlueskyAuthor): APIUser => ({
   joined: author.createdAt,
   birthday: { day: 0, month: 0, year: 0 },
   website: null,
-  profile_embed: true
+  profile_embed: true,
+  type: 'profile'
 });
 
 const tombstoneAuthor = (handleOrDid: string): APIUser => ({
@@ -55,7 +56,8 @@ const tombstoneAuthor = (handleOrDid: string): APIUser => ({
   joined: '',
   birthday: { day: 0, month: 0, year: 0 },
   website: null,
-  profile_embed: true
+  profile_embed: true,
+  type: 'profile'
 });
 
 /** Map a hydrated record embed view into the `BlueskyPost` shape our pipeline expects. */
@@ -341,7 +343,8 @@ export const buildAPIBlueskyPost = async (
     replying_to: await resolveReplyingTo(status, bskyFetchOpts),
     source: 'Bluesky Social',
     embed_card: 'tweet',
-    provider: DataProvider.Bluesky
+    provider: DataProvider.Bluesky,
+    type: 'status'
   };
 
   await applyEmbedsToStatus(apiStatus, status);

--- a/src/providers/bluesky/profile.ts
+++ b/src/providers/bluesky/profile.ts
@@ -37,7 +37,8 @@ export const blueskyProfileToApiUser = (profile: BlueskyProfileViewDetailed): AP
     joined,
     birthday: { day: 0, month: 0, year: 0 },
     website: null,
-    profile_embed: false
+    profile_embed: false,
+    type: 'profile'
   };
 
   if (profile.verification?.verifiedStatus === 'valid') {

--- a/src/providers/bluesky/profileFollowers.ts
+++ b/src/providers/bluesky/profileFollowers.ts
@@ -45,7 +45,8 @@ export const blueskyProfileViewToApiUser = (view: BlueskyProfileView): APIUser =
     joined,
     birthday: { day: 0, month: 0, year: 0 },
     website: null,
-    profile_embed: false
+    profile_embed: false,
+    type: 'profile'
   };
 
   if (view.verification?.verifiedStatus === 'valid') {

--- a/src/providers/bluesky/profileStatuses.ts
+++ b/src/providers/bluesky/profileStatuses.ts
@@ -107,6 +107,10 @@ async function feedViewPostsToGroupedTimeline(
       await Promise.all(g.map(item => buildStatusFromFeedItem(c, item, language)))
     ).filter((s): s is APIBlueskyStatus => s !== null);
     if (built.length === 0) continue;
+    if (built.length === 1) {
+      out.push(built[0]);
+      continue;
+    }
     const newestRec = g[0].post?.record as { reply?: { root?: { uri?: string } } } | undefined;
     const rootUri = newestRec?.reply?.root?.uri;
     const conversation_id = rkeyFromPostAtUri(rootUri) ?? built[built.length - 1].id;

--- a/src/providers/bluesky/profileStatuses.ts
+++ b/src/providers/bluesky/profileStatuses.ts
@@ -3,10 +3,13 @@ import { Constants } from '../../constants';
 import type {
   APIBlueskyStatus,
   APIRepostedBy,
-  APISearchResultsBluesky
+  APIGroupedSearchResultsBluesky,
+  APISearchResultsBluesky,
+  TimelineEntryBluesky
 } from '../../realms/api/schemas';
 import { buildAPIBlueskyPost } from './processor';
 import { fetchActorLikes, fetchAuthorFeed } from './client';
+import { rkeyFromPostAtUri } from './uris';
 
 const REASON_REPOST = 'app.bsky.feed.defs#reasonRepost';
 
@@ -35,26 +38,95 @@ function normalizePostView(post: BlueskyPost): BlueskyPost {
   };
 }
 
+async function buildStatusFromFeedItem(
+  c: Context,
+  item: BlueskyFeedViewPost,
+  language?: string
+): Promise<APIBlueskyStatus | null> {
+  const raw = item.post;
+  if (!raw?.uri || !raw.cid) return null;
+  const post = normalizePostView(raw);
+  try {
+    const status = await buildAPIBlueskyPost(c, post, language);
+    const rb = repostedByFromFeedReason(item.reason);
+    return (rb ? { ...status, reposted_by: rb } : status) as APIBlueskyStatus;
+  } catch (err) {
+    console.error('Error building Bluesky profile timeline post', err);
+    return null;
+  }
+}
+
+/** Consecutive rows where each post replies to the previous (same author), feed order newest-first. */
+export function groupConsecutiveSelfReplies(feed: BlueskyFeedViewPost[]): BlueskyFeedViewPost[][] {
+  const groups: BlueskyFeedViewPost[][] = [];
+  let i = 0;
+  while (i < feed.length) {
+    if (feed[i].reason) {
+      groups.push([feed[i]]);
+      i++;
+      continue;
+    }
+    let j = i;
+    while (j + 1 < feed.length && !feed[j + 1].reason) {
+      const newer = feed[j];
+      const older = feed[j + 1];
+      const newerDid = newer.post?.author?.did;
+      const olderDid = older.post?.author?.did;
+      if (!newerDid || newerDid !== olderDid) break;
+      const rec = newer.post?.record as { reply?: { parent?: { uri?: string } } } | undefined;
+      const parentUri = rec?.reply?.parent?.uri;
+      if (parentUri !== older.post?.uri) break;
+      j++;
+    }
+    if (j > i) {
+      groups.push(feed.slice(i, j + 1));
+      i = j + 1;
+    } else {
+      groups.push([feed[i]]);
+      i++;
+    }
+  }
+  return groups;
+}
+
+async function feedViewPostsToGroupedTimeline(
+  c: Context,
+  feed: BlueskyFeedViewPost[],
+  language?: string
+): Promise<TimelineEntryBluesky[]> {
+  const groups = groupConsecutiveSelfReplies(feed);
+  const out: TimelineEntryBluesky[] = [];
+
+  for (const g of groups) {
+    if (g.length === 1) {
+      const s = await buildStatusFromFeedItem(c, g[0], language);
+      if (s) out.push(s);
+      continue;
+    }
+    const built = (
+      await Promise.all(g.map(item => buildStatusFromFeedItem(c, item, language)))
+    ).filter((s): s is APIBlueskyStatus => s !== null);
+    if (built.length === 0) continue;
+    const newestRec = g[0].post?.record as { reply?: { root?: { uri?: string } } } | undefined;
+    const rootUri = newestRec?.reply?.root?.uri;
+    const conversation_id = rkeyFromPostAtUri(rootUri) ?? built[built.length - 1].id;
+    const chronological = [...built].reverse();
+    out.push({
+      type: 'thread',
+      conversation_id,
+      statuses: chronological,
+      truncated: false
+    });
+  }
+  return out;
+}
+
 async function feedViewPostsToTimeline(
   c: Context,
   feed: BlueskyFeedViewPost[],
   language?: string
 ): Promise<APIBlueskyStatus[]> {
-  const built = await Promise.all(
-    feed.map(async item => {
-      const raw = item.post;
-      if (!raw?.uri || !raw.cid) return null;
-      const post = normalizePostView(raw);
-      try {
-        const status = await buildAPIBlueskyPost(c, post, language);
-        const rb = repostedByFromFeedReason(item.reason);
-        return (rb ? { ...status, reposted_by: rb } : status) as APIBlueskyStatus;
-      } catch (err) {
-        console.error('Error building Bluesky profile timeline post', err);
-        return null;
-      }
-    })
-  );
+  const built = await Promise.all(feed.map(item => buildStatusFromFeedItem(c, item, language)));
   return built.filter((s): s is APIBlueskyStatus => s !== null);
 }
 
@@ -65,9 +137,10 @@ async function blueskyAuthorFeedSearchPage(
     cursor: string | null;
     filter: BlueskyAuthorFeedFilter;
     language?: string;
+    groupThreads?: boolean;
   },
   c: Context
-): Promise<APISearchResultsBluesky> {
+): Promise<APISearchResultsBluesky | APIGroupedSearchResultsBluesky> {
   const result = await fetchAuthorFeed(
     {
       actor,
@@ -87,7 +160,9 @@ async function blueskyAuthorFeedSearchPage(
 
   const feed = result.data.feed ?? [];
   const nextCursor = result.data.cursor ?? null;
-  const results = await feedViewPostsToTimeline(c, feed, options.language);
+  const results = options.groupThreads
+    ? await feedViewPostsToGroupedTimeline(c, feed, options.language)
+    : await feedViewPostsToTimeline(c, feed, options.language);
 
   return {
     code: 200,
@@ -103,16 +178,23 @@ export const blueskyProfileStatusesAPI = async (
     cursor: string | null;
     withReplies: boolean;
     language?: string;
+    groupThreads?: boolean;
   },
   c: Context
-): Promise<APISearchResultsBluesky> => {
+): Promise<APISearchResultsBluesky | APIGroupedSearchResultsBluesky> => {
   const filter: BlueskyAuthorFeedFilter = options.withReplies
     ? 'posts_with_replies'
     : 'posts_no_replies';
 
   return blueskyAuthorFeedSearchPage(
     actor,
-    { count: options.count, cursor: options.cursor, filter, language: options.language },
+    {
+      count: options.count,
+      cursor: options.cursor,
+      filter,
+      language: options.language,
+      groupThreads: options.groupThreads
+    },
     c
   );
 };

--- a/src/providers/mastodon/processor.ts
+++ b/src/providers/mastodon/processor.ts
@@ -211,7 +211,10 @@ const facetFromMastodonNoteAnchor = (
   }
 
   const isMentionClass = /\bmention\b/.test(cls);
-  const acctFromUrl = absHref && /^https?:\/\//i.test(absHref) ? accountFromProfileHref(absHref, instanceDomain) : null;
+  const acctFromUrl =
+    absHref && /^https?:\/\//i.test(absHref)
+      ? accountFromProfileHref(absHref, instanceDomain)
+      : null;
 
   if (isMentionClass || acctFromUrl) {
     const acct = acctFromUrl ?? guessAcctFromMentionPlain(innerPlain, instanceDomain);
@@ -263,7 +266,8 @@ const plainTextAndFacetsFromMastodonNote = (
 
   const facets: APIFacet[] = [];
   const anchorRe = /<a\s+([^>]*)>([\s\S]*?)<\/a>/gi;
-  const parts: Array<{ kind: 'text'; html: string } | { kind: 'a'; attrs: string; inner: string }> = [];
+  const parts: Array<{ kind: 'text'; html: string } | { kind: 'a'; attrs: string; inner: string }> =
+    [];
   let lastIdx = 0;
   let m: RegExpExecArray | null;
   while ((m = anchorRe.exec(normalized)) !== null) {
@@ -288,7 +292,14 @@ const plainTextAndFacetsFromMastodonNote = (
     text += innerPlain;
     const end = text.length;
     const href = extractAttr(p.attrs, 'href');
-    const facet = facetFromMastodonNoteAnchor(p.attrs, href, innerPlain, start, end, instanceDomain);
+    const facet = facetFromMastodonNoteAnchor(
+      p.attrs,
+      href,
+      innerPlain,
+      start,
+      end,
+      instanceDomain
+    );
     if (facet) facets.push(facet);
   }
 
@@ -422,7 +433,8 @@ export const mastodonAccountToApiUser = (account: MastodonAccount, domain: strin
             verified_at: null
           }
         }
-      : {})
+      : {}),
+    type: 'profile'
   };
 };
 
@@ -556,7 +568,8 @@ export const buildAPIMastodonPost = async (
     replying_to,
     source: core.application?.name ?? 'Mastodon',
     embed_card: 'tweet',
-    provider: 'mastodon'
+    provider: 'mastodon',
+    type: 'status'
   };
 
   applyMedia(apiStatus, core);

--- a/src/providers/tiktok/processor.ts
+++ b/src/providers/tiktok/processor.ts
@@ -312,7 +312,8 @@ const extractAuthor = (video: TikTokItemInfo | TikTokAwemeDetail): APIUser => {
         type: null,
         verified_at: null,
         identity_verified: false
-      }
+      },
+      type: 'profile'
     };
   } else if (isMobileApiData(video)) {
     const author = video.author;
@@ -338,7 +339,8 @@ const extractAuthor = (video: TikTokItemInfo | TikTokAwemeDetail): APIUser => {
       statuses: author?.aweme_count || 0,
       joined: '',
       birthday: null,
-      website: null
+      website: null,
+      type: 'profile'
     };
   }
   return {
@@ -359,7 +361,8 @@ const extractAuthor = (video: TikTokItemInfo | TikTokAwemeDetail): APIUser => {
     statuses: 0,
     joined: '',
     birthday: { day: 0, month: 0, year: 0 },
-    website: null
+    website: null,
+    type: 'profile'
   };
 };
 
@@ -543,7 +546,8 @@ export const buildAPITikTokStatus = async (
     replying_to: null,
     source: music ? `♪ ${music.title} - ${music.author}` : 'TikTok',
     embed_card: 'tweet',
-    provider: DataProvider.TikTok
+    provider: DataProvider.TikTok,
+    type: 'status'
   };
 
   // Handle video posts first (prioritize videos over images)

--- a/src/providers/twitter/processor.ts
+++ b/src/providers/twitter/processor.ts
@@ -219,7 +219,7 @@ export const buildAPITwitterStatus = async (
     console.log('Tweet missing author on core', status.rest_id ?? status.legacy?.id_str);
     return null;
   }
-  const apiUser = convertToApiUser(graphQLUser);
+  const apiUser = convertToApiUser(graphQLUser, legacyAPI);
 
   /* Sometimes, `rest_id` is undefined for some reason. Inconsistent behavior. See: https://github.com/FxEmbed/FxEmbed/issues/416 */
   const id = status.rest_id ?? status.legacy.id_str ?? status.legacy?.conversation_id_str;
@@ -233,6 +233,9 @@ export const buildAPITwitterStatus = async (
   }
 
   /* Populating a lot of the basics */
+  if (!legacyAPI) {
+    apiStatus.type = 'status';
+  }
   apiStatus.url = `${Constants.TWITTER_ROOT}/${apiUser.screen_name}/status/${id}`;
   apiStatus.id = id;
   apiStatus.text = unescapeText(
@@ -444,12 +447,14 @@ export const buildAPITwitterStatus = async (
 
     if (status.author_community_relationship.community_results.result.admin_results?.result) {
       apiStatus.community.admin = convertToApiUser(
-        status.author_community_relationship.community_results.result.admin_results.result
+        status.author_community_relationship.community_results.result.admin_results.result,
+        legacyAPI
       );
     }
     if (status.author_community_relationship.community_results.result.creator_results?.result) {
       apiStatus.community.creator = convertToApiUser(
-        status.author_community_relationship.community_results.result.creator_results.result
+        status.author_community_relationship.community_results.result.creator_results.result,
+        legacyAPI
       );
     }
   }

--- a/src/providers/twitter/profile.ts
+++ b/src/providers/twitter/profile.ts
@@ -210,6 +210,10 @@ export const convertToApiUser = (user: GraphQLUser, legacyAPI = false): APIUser 
     };
   }
 
+  if (!legacyAPI) {
+    apiUser.type = 'profile';
+  }
+
   return apiUser;
 };
 

--- a/src/providers/twitter/search.ts
+++ b/src/providers/twitter/search.ts
@@ -132,6 +132,197 @@ export const processTimelineInstructions = (
   return { statuses, cursors };
 };
 
+/** One timeline row: a single tweet or a grouped conversation module (profile timelines). */
+export type GroupedTimelineEntry =
+  | { kind: 'status'; status: GraphQLTwitterStatus }
+  | {
+      kind: 'thread';
+      conversation_id: string;
+      statuses: GraphQLTwitterStatus[];
+      all_status_ids?: string[];
+    };
+
+const conversationIdFromModuleEntry = (
+  entryId: string | undefined,
+  moduleStatuses: GraphQLTwitterStatus[]
+): string => {
+  if (entryId) {
+    const m = entryId.match(/profile-conversation-(\d+)/);
+    if (m) return m[1];
+    const m2 = entryId.match(/conversationthread-(\d+)/);
+    if (m2) return m2[1];
+  }
+  const conv = moduleStatuses[0]?.legacy?.conversation_id_str;
+  if (conv) return conv;
+  return moduleStatuses[0]?.rest_id ?? moduleStatuses[0]?.legacy?.id_str ?? 'unknown';
+};
+
+/** X sometimes nests `conversationMetadata` under `metadata` or on the module/entry root. */
+const conversationMetadataAllTweetIds = (source: unknown): string[] | undefined => {
+  if (!source || typeof source !== 'object') return undefined;
+  const o = source as Record<string, unknown>;
+  const readIds = (cm: unknown): string[] | undefined => {
+    if (!cm || typeof cm !== 'object') return undefined;
+    const ids = (cm as { allTweetIds?: unknown }).allTweetIds;
+    if (Array.isArray(ids) && ids.length > 0 && ids.every(x => typeof x === 'string')) {
+      return ids as string[];
+    }
+    return undefined;
+  };
+  const fromNested = readIds(o.conversationMetadata);
+  if (fromNested) return fromNested;
+  const meta = o.metadata;
+  if (meta && typeof meta === 'object') {
+    const fromMeta = readIds((meta as { conversationMetadata?: unknown }).conversationMetadata);
+    if (fromMeta) return fromMeta;
+  }
+  return undefined;
+};
+
+const allTweetIdsForConversationModule = (
+  module: GraphQLTimelineModule,
+  timelineEntry?: unknown
+): string[] | undefined => {
+  return conversationMetadataAllTweetIds(module) ?? conversationMetadataAllTweetIds(timelineEntry);
+};
+
+/**
+ * Like {@link processTimelineInstructions} but preserves `TimelineTimelineModule` groups
+ * for profile-style conversation rows.
+ */
+export const processGroupedTimelineInstructions = (
+  instructions: TimelineInstruction[]
+): { entries: GroupedTimelineEntry[]; cursors: GraphQLTimelineCursor[] } => {
+  const entries: GroupedTimelineEntry[] = [];
+  const cursors: GraphQLTimelineCursor[] = [];
+
+  type ItemContentWithTweet = {
+    __typename?: string;
+    tweet_results?: { result?: { __typename?: string; tweet?: unknown } };
+  };
+
+  const tweetFromItemContent = (itemContent: ItemContentWithTweet): GraphQLTwitterStatus | null => {
+    if (itemContent?.__typename !== 'TimelineTweet') return null;
+    const result = itemContent.tweet_results?.result;
+    const entryType = result?.__typename;
+    if (entryType === 'Tweet') {
+      return result as GraphQLTwitterStatus;
+    }
+    if (entryType === 'TweetWithVisibilityResults') {
+      return (result as { tweet: GraphQLTwitterStatus }).tweet;
+    }
+    return null;
+  };
+
+  const getItemContent = (
+    item: GraphQLTimelineItem
+  ): GraphQLTimelineTweet | GraphQLTimelineCursor | undefined => {
+    return item.itemContent ?? item.content;
+  };
+
+  const pushModuleAsEntries = (
+    module: GraphQLTimelineModule,
+    outerEntryId: string | undefined,
+    timelineEntry?: unknown
+  ): void => {
+    const statuses: GraphQLTwitterStatus[] = [];
+    module.items?.forEach(item => {
+      const inner = getItemContent(item.item);
+      if (!inner) return;
+      if (inner.__typename === 'TimelineTweet') {
+        const st = tweetFromItemContent(inner as ItemContentWithTweet);
+        if (st) statuses.push(st);
+      } else if (inner.__typename === 'TimelineTimelineCursor') {
+        cursors.push(normalizeCursor(inner as GraphQLTimelineCursor));
+      }
+    });
+    if (statuses.length === 0) return;
+
+    const allIds = allTweetIdsForConversationModule(module, timelineEntry);
+    const useThread =
+      statuses.length > 1 || (allIds !== undefined && allIds.length > statuses.length);
+
+    if (useThread) {
+      entries.push({
+        kind: 'thread',
+        conversation_id: conversationIdFromModuleEntry(outerEntryId, statuses),
+        statuses,
+        all_status_ids: allIds
+      });
+    } else {
+      entries.push({ kind: 'status', status: statuses[0] });
+    }
+  };
+
+  instructions?.forEach(instruction => {
+    const kind =
+      (instruction as { type?: string }).type ??
+      (instruction as { __typename?: string }).__typename;
+
+    if (kind === 'TimelineReplaceEntry') {
+      const content = (instruction as TimelineReplaceEntryInstruction).entry?.content;
+      if (content?.__typename === 'TimelineTimelineCursor') {
+        cursors.push(normalizeCursor(content));
+      }
+      return;
+    }
+
+    if (kind === 'TimelineAddToModule') {
+      (instruction as TimelineAddModulesInstruction).moduleItems?.forEach(_moduleItem => {
+        const moduleItem = _moduleItem as {
+          item?: { itemContent?: unknown; content?: unknown };
+        };
+        const itemContent = moduleItem?.item?.itemContent ?? moduleItem?.item?.content;
+        if (!itemContent) return;
+        const st = tweetFromItemContent(itemContent as ItemContentWithTweet);
+        if (st) entries.push({ kind: 'status', status: st });
+        if (
+          typeof itemContent === 'object' &&
+          itemContent !== null &&
+          (itemContent as { __typename?: string }).__typename === 'TimelineTimelineCursor'
+        ) {
+          cursors.push(normalizeCursor(itemContent as GraphQLTimelineCursor));
+        }
+      });
+      return;
+    }
+
+    if (kind === 'TimelineAddEntries') {
+      (instruction as TimelineAddEntriesInstruction).entries?.forEach(_entry => {
+        const entry = _entry as GraphQLTimelineTweetEntry | GraphQLConversationThread;
+        const content = entry.content as
+          | GraphQLTimelineItem
+          | GraphQLTimelineCursor
+          | GraphQLTimelineModule
+          | undefined;
+        const entryId = (entry as { entryId?: string }).entryId;
+
+        if (typeof content === 'undefined') return;
+
+        if ((content as GraphQLTimelineItem).__typename === 'TimelineTimelineItem') {
+          const inner = getItemContent(content as GraphQLTimelineItem);
+          if (inner) {
+            if (inner.__typename === 'TimelineTweet') {
+              const st = tweetFromItemContent(inner as ItemContentWithTweet);
+              if (st) entries.push({ kind: 'status', status: st });
+            } else if (inner.__typename === 'TimelineTimelineCursor') {
+              cursors.push(normalizeCursor(inner as GraphQLTimelineCursor));
+            }
+          }
+        } else if (isGraphQLTimelineCursor(content)) {
+          cursors.push(normalizeCursor(content));
+        } else if (
+          (content as unknown as GraphQLTimelineModule).__typename === 'TimelineTimelineModule'
+        ) {
+          pushModuleAsEntries(content as GraphQLTimelineModule, entryId, entry);
+        }
+      });
+    }
+  });
+
+  return { entries, cursors };
+};
+
 type ItemContentWithUser = {
   __typename?: string;
   user_results?: { result?: { __typename?: string } };

--- a/src/providers/twitter/typeahead.ts
+++ b/src/providers/twitter/typeahead.ts
@@ -118,7 +118,8 @@ export const typeaheadUserToApiUser = (u: TwitterTypeaheadUser): APIUser | null 
     likes: 0,
     joined: '',
     website: null,
-    verification
+    verification,
+    type: 'profile'
   };
 };
 

--- a/src/providers/twitter/userStatuses.ts
+++ b/src/providers/twitter/userStatuses.ts
@@ -33,11 +33,17 @@ import {
   getTwitterUserRestIdByScreenName,
   type ProfileHandleOrId
 } from './profile';
-import { processTimelineInstructions, processUserRelationshipTimelineInstructions } from './search';
+import {
+  processTimelineInstructions,
+  processGroupedTimelineInstructions,
+  processUserRelationshipTimelineInstructions
+} from './search';
 import type {
   APIProfileRelationshipList,
+  APIGroupedSearchResults,
   APISearchResults,
-  APITwitterStatus
+  APITwitterStatus,
+  TimelineEntryTwitter
 } from '../../realms/api/schemas';
 
 export const profileStatusesAPI = async (
@@ -46,8 +52,9 @@ export const profileStatusesAPI = async (
   cursor: string | null,
   c: Context,
   withReplies = false,
-  language?: string
-): Promise<APISearchResults> => {
+  language?: string,
+  groupThreads = false
+): Promise<APISearchResults | APIGroupedSearchResults> => {
   const userId =
     handleOrId.type === 'userId'
       ? handleOrId.value
@@ -107,6 +114,64 @@ export const profileStatusesAPI = async (
   const instructions = getProfileStatusesTimelineInstructions(results.tweets.data);
   if (!instructions) {
     return { code: 404, results: [], cursor: { top: null, bottom: null } };
+  }
+
+  if (groupThreads) {
+    const { entries, cursors } = processGroupedTimelineInstructions(instructions);
+    const topCursor = cursors.find(cur => cur.cursorType === 'Top')?.value ?? null;
+    const bottomCursor = cursors.find(cur => cur.cursorType === 'Bottom')?.value ?? null;
+
+    const builtResults = (
+      await Promise.all(
+        entries.map(async (e): Promise<TimelineEntryTwitter | null> => {
+          if (e.kind === 'status') {
+            const s = await buildAPITwitterStatus(c, e.status, language, null, false, false).catch(
+              err => {
+                console.error('Error building status', err);
+                return null;
+              }
+            );
+            return s !== null && !(s as FetchResults)?.status ? s : null;
+          }
+          const built = (
+            await Promise.all(
+              e.statuses.map(st =>
+                buildAPITwitterStatus(c, st, language, null, false, false).catch(err => {
+                  console.error('Error building status', err);
+                  return null;
+                })
+              )
+            )
+          ).filter((s): s is APITwitterStatus => s !== null && !(s as FetchResults)?.status);
+
+          if (built.length === 0) return null;
+
+          if (built.length === 1 && (!e.all_status_ids || e.all_status_ids.length <= 1)) {
+            return built[0];
+          }
+
+          const allIds = e.all_status_ids;
+          const truncated = allIds !== undefined && allIds.length > built.length;
+
+          return {
+            type: 'thread' as const,
+            conversation_id: e.conversation_id,
+            statuses: built,
+            truncated,
+            ...(allIds && allIds.length > 0 ? { all_status_ids: allIds } : {})
+          };
+        })
+      )
+    ).filter((x): x is TimelineEntryTwitter => x !== null);
+
+    return {
+      code: 200,
+      results: builtResults,
+      cursor: {
+        top: topCursor,
+        bottom: bottomCursor
+      }
+    };
   }
 
   const { statuses, cursors } = processTimelineInstructions(instructions);

--- a/src/realms/api/routes.ts
+++ b/src/realms/api/routes.ts
@@ -8,6 +8,7 @@ import {
   APIProfileRelationshipListSchema,
   APIUserListResultsSchema,
   APISearchResultsSchema,
+  APIGroupedSearchResultsSchema,
   APITypeaheadResponseSchema,
   APITrendsResponseSchema,
   ApiQueryErrorSchema,
@@ -347,13 +348,21 @@ export const profileStatusesV2Route = createRoute({
         description:
           'If truthy (`1`, `true`, `yes`, `on`, or empty), include replies using alternate upstream timelines'
       }),
+      groupthreads: z.string().optional().openapi({
+        description:
+          'If truthy (`1`, `true`, etc.), return `results` as a mix of `type: "status"` and `type: "thread"` entries (grouped conversation rows).'
+      }),
       ...langQuery.shape
     })
   },
   responses: {
     200: {
-      description: 'Timeline page',
-      content: { 'application/json': { schema: APISearchResultsSchema } }
+      description: 'Timeline page (flat or grouped when `groupthreads` is set)',
+      content: {
+        'application/json': {
+          schema: z.union([APISearchResultsSchema, APIGroupedSearchResultsSchema])
+        }
+      }
     },
     204: {
       description:

--- a/src/realms/api/routes/twitter.ts
+++ b/src/realms/api/routes/twitter.ts
@@ -1,3 +1,4 @@
+import type { APITwitterStatus } from '../schemas';
 import {
   constructTwitterThread,
   constructTwitterConversation,
@@ -212,6 +213,7 @@ export const profileStatusesAPIRequest = (async (c): Promise<TwitterProfileStatu
   const count = query.count ?? 20;
   const cursor = query.cursor ?? null;
   const withReplies = isParamTruthy(query.with_replies ?? c.req.query('withReplies'));
+  const groupThreads = isParamTruthy(query.groupthreads ?? c.req.query('groupthreads'));
   const sinceParam = query.since;
 
   const statusesResponse = await profileStatusesAPI(
@@ -220,7 +222,8 @@ export const profileStatusesAPIRequest = (async (c): Promise<TwitterProfileStatu
     cursor,
     c,
     withReplies,
-    query.lang
+    query.lang,
+    groupThreads
   );
 
   const applySinceNoContent =
@@ -228,7 +231,14 @@ export const profileStatusesAPIRequest = (async (c): Promise<TwitterProfileStatu
 
   if (applySinceNoContent) {
     const sinceMs = unixTimestampParamToMs(sinceParam);
-    const hasNewerPost = statusesResponse.results.some(s => {
+    const hasNewerPost = statusesResponse.results.some(item => {
+      if ('type' in item && item.type === 'thread') {
+        return item.statuses.some(s => {
+          const tMs = s.created_timestamp * 1000;
+          return Number.isFinite(tMs) && tMs > sinceMs;
+        });
+      }
+      const s = item as APITwitterStatus;
       const tMs = s.created_timestamp * 1000;
       return Number.isFinite(tMs) && tMs > sinceMs;
     });

--- a/src/realms/api/schemas.ts
+++ b/src/realms/api/schemas.ts
@@ -96,6 +96,9 @@ export const APIAboutAccountSchema = z
 
 export const APIUserSchema = z
   .object({
+    type: z
+      .literal('profile')
+      .openapi({ description: 'Discriminator: full user profile (API v2).' }),
     id: z.string(),
     name: z.string(),
     screen_name: z.string(),
@@ -485,12 +488,16 @@ export type APITwitterStatus = {
     | null;
   reposted_by: z.infer<typeof APIRepostedBySchema> | null;
   card?: z.infer<typeof APICardSchema>;
+  type: 'status';
 };
 
 /* Self-referential `z.lazy` needs `z.ZodType<APITwitterStatus>` so output is not widened to `unknown`. */
 export const APITwitterStatusSchema: z.ZodType<APITwitterStatus> = z
   .lazy(() =>
     z.object({
+      type: z
+        .literal('status')
+        .openapi({ description: 'Discriminator: single post/status (API v2).' }),
       id: z.string(),
       url: z.string(),
       text: z.string(),
@@ -575,11 +582,15 @@ export type APIBlueskyStatus = {
   provider: 'bluesky';
   /** Present when this row is a repost (`reasonRepost` in author feed). */
   reposted_by?: z.infer<typeof APIRepostedBySchema>;
+  type: 'status';
 };
 
 export const APIBlueskyStatusSchema: z.ZodType<APIBlueskyStatus> = z
   .lazy(() =>
     z.object({
+      type: z
+        .literal('status')
+        .openapi({ description: 'Discriminator: single post/status (API v2).' }),
       id: z.string(),
       cid: z.string().optional(),
       at_uri: z.string().optional(),
@@ -705,8 +716,64 @@ export const APISearchResultsBlueskySchema = z
   })
   .openapi('APISearchResultsBluesky');
 
+/** Grouped thread snippet in a profile/search-style timeline (`?groupthreads=1`). */
+export const TimelineThreadTwitterSchema = z
+  .object({
+    type: z.literal('thread').openapi({
+      description: 'Discriminator: grouped conversation snippet in a timeline (API v2).'
+    }),
+    conversation_id: z.string(),
+    statuses: z.array(APITwitterStatusSchema),
+    all_status_ids: z.array(z.string()).optional(),
+    truncated: z.boolean().openapi({
+      description:
+        'True when the conversation has more posts than listed in `statuses` (Twitter: `allTweetIds` length vs visible). False when counts match or upstream did not provide `allTweetIds`.'
+    })
+  })
+  .openapi('TimelineThreadTwitter');
+
+export const TimelineEntryTwitterSchema = z
+  .discriminatedUnion('type', [APITwitterStatusSchema, TimelineThreadTwitterSchema])
+  .openapi('TimelineEntryTwitter');
+
+export const APIGroupedSearchResultsSchema = z
+  .object({
+    code: z.number(),
+    results: z.array(TimelineEntryTwitterSchema),
+    cursor: SearchCursorSchema
+  })
+  .openapi('APIGroupedSearchResults');
+
+export const TimelineThreadBlueskySchema = z
+  .object({
+    type: z.literal('thread').openapi({
+      description: 'Discriminator: grouped conversation snippet in a timeline (API v2).'
+    }),
+    conversation_id: z.string(),
+    statuses: z.array(APIBlueskyStatusSchema),
+    all_status_ids: z.array(z.string()).optional(),
+    truncated: z.boolean().openapi({
+      description:
+        'Always false for Bluesky grouped timelines (no native full-thread id list on feed rows).'
+    })
+  })
+  .openapi('TimelineThreadBluesky');
+
+export const TimelineEntryBlueskySchema = z
+  .discriminatedUnion('type', [APIBlueskyStatusSchema, TimelineThreadBlueskySchema])
+  .openapi('TimelineEntryBluesky');
+
+export const APIGroupedSearchResultsBlueskySchema = z
+  .object({
+    code: z.number(),
+    results: z.array(TimelineEntryBlueskySchema),
+    cursor: SearchCursorSchema
+  })
+  .openapi('APIGroupedSearchResultsBluesky');
+
 /** Mastodon / ActivityPub normalized post (same baseline as Bluesky API v2). */
 export type APIMastodonStatus = {
+  type: 'status';
   id: string;
   url: string;
   text: string;
@@ -740,6 +807,9 @@ export type APIMastodonStatus = {
 export const APIMastodonStatusSchema: z.ZodType<APIMastodonStatus> = z
   .lazy(() =>
     z.object({
+      type: z
+        .literal('status')
+        .openapi({ description: 'Discriminator: single post/status (API v2).' }),
       id: z.string(),
       url: z.string(),
       text: z.string(),
@@ -929,6 +999,12 @@ export type ProfileAboutAPIResponse = z.infer<typeof ProfileAboutAPIResponseSche
 export type SearchCursor = z.infer<typeof SearchCursorSchema>;
 export type APISearchResults = z.infer<typeof APISearchResultsSchema>;
 export type APISearchResultsBluesky = z.infer<typeof APISearchResultsBlueskySchema>;
+export type TimelineThreadTwitter = z.infer<typeof TimelineThreadTwitterSchema>;
+export type TimelineEntryTwitter = z.infer<typeof TimelineEntryTwitterSchema>;
+export type APIGroupedSearchResults = z.infer<typeof APIGroupedSearchResultsSchema>;
+export type TimelineThreadBluesky = z.infer<typeof TimelineThreadBlueskySchema>;
+export type TimelineEntryBluesky = z.infer<typeof TimelineEntryBlueskySchema>;
+export type APIGroupedSearchResultsBluesky = z.infer<typeof APIGroupedSearchResultsBlueskySchema>;
 export type APISearchResultsMastodon = z.infer<typeof APISearchResultsMastodonSchema>;
 export type APIProfileRelationshipList = z.infer<typeof APIProfileRelationshipListSchema>;
 export type APIUserListResults = z.infer<typeof APIUserListResultsSchema>;

--- a/src/realms/bluesky-api/handlers.ts
+++ b/src/realms/bluesky-api/handlers.ts
@@ -1,4 +1,5 @@
 import type { RouteHandler } from '@hono/zod-openapi';
+import type { APIBlueskyStatus } from '../api/schemas';
 import { Constants } from '../../constants';
 import { jsonAfterNormalize, normalizeApiJsonResponse } from '../api/normalizeApiJsonResponse';
 import { isParamTruthy } from '../../helpers/utils';
@@ -311,6 +312,7 @@ export const blueskyProfileStatusesAPIRequest = (async (
   const count = query.count ?? 20;
   const cursor = query.cursor ?? null;
   const withReplies = isParamTruthy(query.with_replies ?? c.req.query('withReplies'));
+  const groupThreads = isParamTruthy(query.groupthreads ?? c.req.query('groupthreads'));
   const sinceParam = query.since;
 
   const statusesResponse = await blueskyProfileStatusesAPI(
@@ -319,7 +321,8 @@ export const blueskyProfileStatusesAPIRequest = (async (
       count,
       cursor,
       withReplies,
-      language: query.lang
+      language: query.lang,
+      groupThreads
     },
     c
   );
@@ -329,7 +332,14 @@ export const blueskyProfileStatusesAPIRequest = (async (
 
   if (applySinceNoContent) {
     const sinceMs = unixTimestampParamToMs(sinceParam);
-    const hasNewerPost = statusesResponse.results.some(s => {
+    const hasNewerPost = statusesResponse.results.some(item => {
+      if ('type' in item && item.type === 'thread') {
+        return item.statuses.some(s => {
+          const tMs = s.created_timestamp * 1000;
+          return Number.isFinite(tMs) && tMs > sinceMs;
+        });
+      }
+      const s = item as APIBlueskyStatus;
       const tMs = s.created_timestamp * 1000;
       return Number.isFinite(tMs) && tMs > sinceMs;
     });

--- a/src/realms/bluesky-api/routes.ts
+++ b/src/realms/bluesky-api/routes.ts
@@ -4,6 +4,7 @@ import {
   APIUserListResultsSchema,
   ApiQueryErrorSchema,
   APISearchResultsBlueskySchema,
+  APIGroupedSearchResultsBlueskySchema,
   APITrendsResponseSchema,
   SocialConversationBlueskySchema,
   SocialThreadBlueskySchema,
@@ -603,13 +604,21 @@ export const blueskyProfileStatusesV2Route = createRoute({
         description:
           'If truthy (`1`, `true`, `yes`, `on`, or empty), include replies (`posts_with_replies` upstream); otherwise `posts_no_replies`.'
       }),
+      groupthreads: z.string().optional().openapi({
+        description:
+          'If truthy, return `results` as a mix of `type: "status"` and `type: "thread"` entries (consecutive self-reply chains grouped).'
+      }),
       ...langQuery.shape
     })
   },
   responses: {
     200: {
-      description: 'Timeline page',
-      content: { 'application/json': { schema: APISearchResultsBlueskySchema } }
+      description: 'Timeline page (flat or grouped when `groupthreads` is set)',
+      content: {
+        'application/json': {
+          schema: z.union([APISearchResultsBlueskySchema, APIGroupedSearchResultsBlueskySchema])
+        }
+      }
     },
     204: {
       description:

--- a/src/realms/bluesky/routes/status.ts
+++ b/src/realms/bluesky/routes/status.ts
@@ -88,7 +88,9 @@ export const blueskyStatusRequest = async (c: Context) => {
         Embeds will return as usual to bots as if direct media was never specified. */
       if (!isBotUA && !flags.api && !flags.direct) {
         return c.redirect(
-          flags.horizon ? horizonBskyStatusUrl : `${Constants.BLUESKY_ROOT}/profile/${handle}/post/${actualId}`,
+          flags.horizon
+            ? horizonBskyStatusUrl
+            : `${Constants.BLUESKY_ROOT}/profile/${handle}/post/${actualId}`,
           302
         );
       }

--- a/src/types/apiStatus.ts
+++ b/src/types/apiStatus.ts
@@ -66,7 +66,8 @@ export interface APIStatus {
   cid?: string;
   /** `at://…/app.bsky.feed.post/…` (Bluesky only). */
   at_uri?: string;
-  type?: 'status';
+  /** Discriminator: single post/status (non-Twitter providers; Twitter uses `APITwitterStatus`). */
+  type: 'status';
 }
 
 export interface APIBlueskyStatus extends APIStatus {
@@ -82,7 +83,6 @@ export interface APIMastodonStatus extends APIStatus {
 export interface APITikTokStatus extends APIStatus {
   provider: DataProvider.TikTok;
   views?: number | null;
-  type?: 'status';
 }
 
 export interface SocialPost {

--- a/src/types/apiStatus.ts
+++ b/src/types/apiStatus.ts
@@ -66,6 +66,7 @@ export interface APIStatus {
   cid?: string;
   /** `at://…/app.bsky.feed.post/…` (Bluesky only). */
   at_uri?: string;
+  type?: 'status';
 }
 
 export interface APIBlueskyStatus extends APIStatus {
@@ -81,6 +82,7 @@ export interface APIMastodonStatus extends APIStatus {
 export interface APITikTokStatus extends APIStatus {
   provider: DataProvider.TikTok;
   views?: number | null;
+  type?: 'status';
 }
 
 export interface SocialPost {

--- a/test/api.openapi.test.ts
+++ b/test/api.openapi.test.ts
@@ -29,3 +29,40 @@ test('GET /2/openapi.json returns OpenAPI 3 document with v2 paths', async () =>
   expect(doc.paths['/2/hit']).toBeUndefined();
   expect(doc.paths['/2/go']).toBeUndefined();
 });
+
+test('FxTwitter OpenAPI includes grouped timeline and v2 type discriminators', async () => {
+  const result = await app.request(
+    new Request('https://api.fxtwitter.com/2/openapi.json', {
+      method: 'GET',
+      headers: botHeaders
+    }),
+    undefined,
+    harness
+  );
+  expect(result.status).toBe(200);
+  const doc = (await result.json()) as {
+    components?: { schemas?: Record<string, { properties?: Record<string, unknown> }> };
+  };
+  const schemas = doc.components?.schemas;
+  expect(schemas?.TimelineEntryTwitter).toBeDefined();
+  expect(schemas?.APIGroupedSearchResults).toBeDefined();
+  expect(schemas?.APITwitterStatus?.properties?.type).toBeDefined();
+  expect(schemas?.APIUser?.properties?.type).toBeDefined();
+});
+
+test('FxBluesky OpenAPI includes grouped timeline entry schema', async () => {
+  const result = await app.request(
+    new Request('https://api.fxbsky.app/2/openapi.json', {
+      method: 'GET',
+      headers: botHeaders
+    }),
+    undefined,
+    harness
+  );
+  expect(result.status).toBe(200);
+  const doc = (await result.json()) as {
+    components?: { schemas?: Record<string, unknown> };
+  };
+  expect(doc.components?.schemas?.TimelineEntryBluesky).toBeDefined();
+  expect(doc.components?.schemas?.APIGroupedSearchResultsBluesky).toBeDefined();
+});

--- a/test/api.profileStatuses.test.ts
+++ b/test/api.profileStatuses.test.ts
@@ -27,12 +27,40 @@ test('API profile statuses returns tweets and cursors for known user', async () 
   expect(typeof response.cursor.bottom).toBe('string');
 
   const first = response.results[0] as APITwitterStatus;
+  expect(first.type).toBe('status');
+  expect(first.author.type).toBe('profile');
   expect(first.id).toEqual('2036082537949434164');
   expect(first.quotes).toEqual(383);
   expect(first.text).toBeTruthy();
   expect(first.url).toContain(twitterBaseUrl);
   expect(first.url).toContain('/status/');
   expect(first.author?.screen_name).toBeTruthy();
+});
+
+test('API profile statuses with groupthreads=1 returns discriminated results', async () => {
+  const result = await app.request(
+    new Request('https://api.fxtwitter.com/2/profile/x/statuses?groupthreads=1&count=5', {
+      method: 'GET',
+      headers: botHeaders
+    }),
+    undefined,
+    harness
+  );
+  expect(result.status).toEqual(200);
+  const response = (await result.json()) as {
+    code: number;
+    results: Array<{ type: 'status' | 'thread' } & Record<string, unknown>>;
+  };
+  expect(response.code).toEqual(200);
+  expect(response.results.length).toBeGreaterThan(0);
+  for (const row of response.results) {
+    expect(row.type === 'status' || row.type === 'thread').toBe(true);
+    if (row.type === 'thread') {
+      expect(Array.isArray(row.statuses)).toBe(true);
+      expect(typeof row.conversation_id).toBe('string');
+      expect(typeof row.truncated).toBe('boolean');
+    }
+  }
 });
 
 test('API profile statuses accepts count and cursor query params', async () => {

--- a/test/bluesky.api.test.ts
+++ b/test/bluesky.api.test.ts
@@ -325,7 +325,36 @@ test('GET /2/profile/{handle}/statuses returns feed, cursor.bottom, and reposted
   expect(body.results.length).toBe(2);
   expect(body.results[0].id).toBe('rkeymain');
   expect(body.results[0].text).toContain('Hello timeline');
+  expect((body.results[0] as { type?: string }).type).toBe('status');
   expect(body.results[1].reposted_by?.screen_name).toBe('reposter.test');
+});
+
+test('GET /2/profile/{handle}/statuses?groupthreads=1 returns discriminated timeline rows', async () => {
+  vi.spyOn(globalThis, 'fetch').mockImplementation(async (input: RequestInfo) => {
+    const u = typeof input === 'string' ? input : input.url;
+    if (u.includes('app.bsky.feed.getAuthorFeed')) {
+      return new Response(JSON.stringify(authorFeed), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+    throw new Error(`Unexpected fetch: ${u}`);
+  });
+
+  const res = await app.request(
+    'https://api.fxbsky.app/2/profile/author.test/statuses?groupthreads=1',
+    { headers: { 'User-Agent': 'FxEmbedTest/1.0' } }
+  );
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as {
+    code: number;
+    results: Array<{ type: 'status' | 'thread'; statuses?: unknown[]; conversation_id?: string }>;
+  };
+  expect(body.code).toBe(200);
+  expect(body.results.length).toBe(2);
+  for (const row of body.results) {
+    expect(row.type === 'status' || row.type === 'thread').toBe(true);
+  }
 });
 
 test('GET /2/profile/{handle}/media uses posts_with_media filter and cursor.bottom', async () => {

--- a/test/bluesky.profileStatuses.grouped.test.ts
+++ b/test/bluesky.profileStatuses.grouped.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { groupConsecutiveSelfReplies } from '../src/providers/bluesky/profileStatuses';
+
+const postView = (
+  uri: string,
+  authorDid: string,
+  replyParentUri: string | null,
+  replyRootUri: string | null
+): BlueskyFeedViewPost => ({
+  post: {
+    uri,
+    cid: `cid-${uri}`,
+    author: { did: authorDid, handle: 'a.bsky.social', displayName: 'A' },
+    record: {
+      $type: 'app.bsky.feed.post',
+      text: uri,
+      createdAt: '2024-01-01T00:00:00.000Z',
+      ...(replyParentUri || replyRootUri
+        ? {
+            reply: {
+              parent: replyParentUri ? { cid: 'p', uri: replyParentUri } : undefined,
+              root: replyRootUri ? { cid: 'r', uri: replyRootUri } : undefined
+            }
+          }
+        : {})
+    },
+    indexedAt: '2024-01-01T00:00:00.000Z',
+    labels: []
+  }
+});
+
+describe('groupConsecutiveSelfReplies', () => {
+  it('groups a newest-first self-reply chain', () => {
+    const did = 'did:plc:abc';
+    const rootUri = 'at://did:plc:abc/app.bsky.feed.post/root1';
+    const midUri = 'at://did:plc:abc/app.bsky.feed.post/mid2';
+    const leafUri = 'at://did:plc:abc/app.bsky.feed.post/leaf3';
+    const feed: BlueskyFeedViewPost[] = [
+      postView(leafUri, did, midUri, rootUri),
+      postView(midUri, did, rootUri, rootUri),
+      postView(rootUri, did, null, null),
+      postView('at://did:plc:other/app.bsky.feed.post/o1', 'did:plc:other', null, null)
+    ];
+    const groups = groupConsecutiveSelfReplies(feed);
+    expect(groups).toHaveLength(2);
+    expect(groups[0].map(g => g.post?.uri)).toEqual([leafUri, midUri, rootUri]);
+    expect(groups[1].map(g => g.post?.uri)).toEqual(['at://did:plc:other/app.bsky.feed.post/o1']);
+  });
+
+  it('does not merge when reply parent is not the adjacent older post', () => {
+    const did = 'did:plc:abc';
+    const a = 'at://did:plc:abc/app.bsky.feed.post/a';
+    const b = 'at://did:plc:abc/app.bsky.feed.post/b';
+    const c = 'at://did:plc:abc/app.bsky.feed.post/c';
+    const feed: BlueskyFeedViewPost[] = [
+      postView(c, did, b, a),
+      postView(a, did, null, null),
+      postView(b, did, a, a)
+    ];
+    const groups = groupConsecutiveSelfReplies(feed);
+    expect(groups).toHaveLength(3);
+  });
+});

--- a/test/bluesky.schemas.test.ts
+++ b/test/bluesky.schemas.test.ts
@@ -30,7 +30,8 @@ test('APIBlueskyStatusSchema parses minimal bluesky-shaped payload', () => {
       media_count: 0,
       likes: 0,
       joined: '',
-      website: null
+      website: null,
+      type: 'profile' as const
     },
     media: { photos: [] },
     raw_text: { text: 'hi', facets: [] },
@@ -39,7 +40,8 @@ test('APIBlueskyStatusSchema parses minimal bluesky-shaped payload', () => {
     replying_to: null,
     source: 'Bluesky Social',
     embed_card: 'tweet',
-    provider: 'bluesky' as const
+    provider: 'bluesky' as const,
+    type: 'status' as const
   };
 
   const r = APIBlueskyStatusSchema.safeParse(sample);

--- a/test/groupedTimelineInstructions.test.ts
+++ b/test/groupedTimelineInstructions.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from 'vitest';
+import { processGroupedTimelineInstructions } from '../src/providers/twitter/search';
+
+const minimalTweet = (id: string, conversationId: string) =>
+  ({
+    __typename: 'Tweet',
+    rest_id: id,
+    core: {
+      user_results: {
+        result: {
+          __typename: 'User',
+          rest_id: '67',
+          core: { screen_name: 'u', name: 'U' },
+          legacy: {
+            screen_name: 'u',
+            name: 'U',
+            followers_count: 0,
+            friends_count: 0,
+            favourites_count: 0,
+            media_count: 0,
+            statuses_count: 0
+          }
+        }
+      }
+    },
+    legacy: {
+      id_str: id,
+      conversation_id_str: conversationId,
+      full_text: `t${id}`,
+      created_at: 'Mon Jan 01 00:00:00 +0000 2024',
+      display_text_range: [0, 1],
+      favorite_count: 0,
+      retweet_count: 0,
+      reply_count: 0,
+      quote_count: 0,
+      entities: { hashtags: [], symbols: [], urls: [], user_mentions: [] },
+      user_id_str: '67'
+    }
+  }) as GraphQLTwitterStatus;
+
+describe('processGroupedTimelineInstructions', () => {
+  it('groups TimelineTimelineModule rows and captures allTweetIds', () => {
+    const t1 = minimalTweet('111', '111');
+    const t2 = minimalTweet('222', '111');
+    const t3 = minimalTweet('333', '111');
+    const instructions: TimelineInstruction[] = [
+      {
+        type: 'TimelineAddEntries',
+        entries: [
+          {
+            entryId: 'profile-conversation-777',
+            sortIndex: '1',
+            content: {
+              __typename: 'TimelineTimelineModule',
+              entryType: 'TimelineTimelineModule',
+              metadata: {
+                conversationMetadata: {
+                  allTweetIds: [
+                    '111',
+                    '222',
+                    '333',
+                    '999'
+                  ]
+                }
+              },
+              items: [
+                {
+                  item: {
+                    itemContent: {
+                      __typename: 'TimelineTweet',
+                      tweet_results: { result: t1 }
+                    }
+                  }
+                },
+                {
+                  item: {
+                    itemContent: {
+                      __typename: 'TimelineTweet',
+                      tweet_results: { result: t2 }
+                    }
+                  }
+                },
+                {
+                  item: {
+                    itemContent: {
+                      __typename: 'TimelineTweet',
+                      tweet_results: { result: t3 }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    ];
+
+    const { entries } = processGroupedTimelineInstructions(instructions);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].kind).toBe('thread');
+    if (entries[0].kind !== 'thread') return;
+    expect(entries[0].conversation_id).toBe('777');
+    expect(entries[0].statuses.map(s => s.rest_id ?? s.legacy?.id_str)).toEqual([
+      '111',
+      '222',
+      '333'
+    ]);
+    expect(entries[0].all_status_ids).toEqual([
+      '111',
+      '222',
+      '333',
+      '999'
+    ]);
+  });
+
+  it('reads allTweetIds from timeline entry when omitted on module content', () => {
+    const t1 = minimalTweet('1', '1');
+    const t2 = minimalTweet('2', '1');
+    const instructions: TimelineInstruction[] = [
+      {
+        type: 'TimelineAddEntries',
+        entries: [
+          {
+            entryId: 'profile-conversation-77',
+            metadata: {
+              conversationMetadata: {
+                allTweetIds: ['1', '2', '3']
+              }
+            },
+            content: {
+              __typename: 'TimelineTimelineModule',
+              entryType: 'TimelineTimelineModule',
+              items: [
+                {
+                  item: {
+                    itemContent: {
+                      __typename: 'TimelineTweet',
+                      tweet_results: { result: t1 }
+                    }
+                  }
+                },
+                {
+                  item: {
+                    itemContent: {
+                      __typename: 'TimelineTweet',
+                      tweet_results: { result: t2 }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    ];
+    const { entries } = processGroupedTimelineInstructions(instructions);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].kind).toBe('thread');
+    if (entries[0].kind !== 'thread') return;
+    expect(entries[0].all_status_ids).toEqual(['1', '2', '3']);
+  });
+
+  it('emits a single status entry for one-tweet module without extra allTweetIds', () => {
+    const t1 = minimalTweet('1', '1');
+    const instructions: TimelineInstruction[] = [
+      {
+        type: 'TimelineAddEntries',
+        entries: [
+          {
+            entryId: 'profile-conversation-99',
+            content: {
+              __typename: 'TimelineTimelineModule',
+              entryType: 'TimelineTimelineModule',
+              items: [
+                {
+                  item: {
+                    itemContent: {
+                      __typename: 'TimelineTweet',
+                      tweet_results: { result: t1 }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    ];
+    const { entries } = processGroupedTimelineInstructions(instructions);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].kind).toBe('status');
+  });
+});

--- a/test/mastodon.profileNoteFacets.test.ts
+++ b/test/mastodon.profileNoteFacets.test.ts
@@ -64,14 +64,19 @@ describe('mastodonAccountToApiUser note facets', () => {
   });
 
   test('preserves spacing around inline links', () => {
-    const note = 'a <a href="https://mastodon.social/tags/x" class="mention hashtag" rel="tag">#x</a> b';
+    const note =
+      'a <a href="https://mastodon.social/tags/x" class="mention hashtag" rel="tag">#x</a> b';
     const u = mastodonAccountToApiUser({ ...baseAccount(), note }, 'mastodon.social');
     expect(u.raw_description.text).toBe('a #x b');
   });
 
   test('custom emoji img becomes :shortcode: and custom_emoji facet', () => {
     const emojis = [
-      { shortcode: 'blobcat', url: 'https://files.example/custom/blobcat.png', static_url: 'https://files.example/static/blobcat.png' }
+      {
+        shortcode: 'blobcat',
+        url: 'https://files.example/custom/blobcat.png',
+        static_url: 'https://files.example/static/blobcat.png'
+      }
     ];
     const note =
       '<p>Hi <img src="https://files.example/custom/blobcat.png" alt=":blobcat:" title=":blobcat:" class="custom-emoji" /></p>';

--- a/test/mastodon.statusEmojiFacets.test.ts
+++ b/test/mastodon.statusEmojiFacets.test.ts
@@ -22,7 +22,9 @@ const baseAccount = (): MastodonAccount => ({
   statuses_count: 0
 });
 
-const minimalStatus = (overrides: Partial<MastodonStatus> & Pick<MastodonStatus, 'content'>): MastodonStatus => ({
+const minimalStatus = (
+  overrides: Partial<MastodonStatus> & Pick<MastodonStatus, 'content'>
+): MastodonStatus => ({
   id: '99',
   uri: 'https://mastodon.social/users/self/statuses/99',
   created_at: '2020-01-01T00:00:00.000Z',
@@ -48,7 +50,11 @@ const minimalStatus = (overrides: Partial<MastodonStatus> & Pick<MastodonStatus,
 describe('buildAPIMastodonPost custom emoji facets', () => {
   test('content img becomes :shortcode: with mention and hashtag facets', async () => {
     const emojis = [
-      { shortcode: 'ruby', url: 'https://files.example/e/ruby.png', static_url: 'https://files.example/s/ruby.png' }
+      {
+        shortcode: 'ruby',
+        url: 'https://files.example/e/ruby.png',
+        static_url: 'https://files.example/s/ruby.png'
+      }
     ];
     const status = minimalStatus({
       content:

--- a/test/profile.convertToApiUser.test.ts
+++ b/test/profile.convertToApiUser.test.ts
@@ -75,6 +75,7 @@ test('convertToApiUser expands bio t.co from entities.description.urls and build
 
   const apiUser = convertToApiUser(user, false);
 
+  expect(apiUser.type).toBe('profile');
   expect(apiUser.description).toContain('http://grok.com/download');
   expect(apiUser.description).not.toMatch(/t\.co\//);
   expect(apiUser.raw_description.text).toEqual(rawBio);

--- a/tools/credential-tools.mjs
+++ b/tools/credential-tools.mjs
@@ -65,10 +65,8 @@ function encrypt() {
 
   const plaintext = readFileSync(PLAINTEXT_PATH, 'utf-8');
   const parsed = JSON.parse(plaintext);
-  const hasTwitter =
-    Array.isArray(parsed?.twitter?.accounts) && parsed.twitter.accounts.length > 0;
-  const hasBluesky =
-    Array.isArray(parsed?.bluesky?.accounts) && parsed.bluesky.accounts.length > 0;
+  const hasTwitter = Array.isArray(parsed?.twitter?.accounts) && parsed.twitter.accounts.length > 0;
+  const hasBluesky = Array.isArray(parsed?.bluesky?.accounts) && parsed.bluesky.accounts.length > 0;
   if (!hasTwitter && !hasBluesky) {
     console.error(
       'credentials.json must include a non-empty twitter.accounts and/or bluesky.accounts array (see credentials.example.json).'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional thread grouping for profile timelines via a new query parameter; timelines can return grouped "thread" entries or regular status rows.
  * Responses now include explicit type discriminators for statuses and profile users for clearer client rendering.

* **Bug Fixes**
  * Improved since/no-content checks to correctly detect newer items inside grouped thread results.

* **Tests**
  * Added OpenAPI and unit tests covering grouped timelines and type discriminators.

* **Documentation**
  * Cleaned up and reformatted agent documentation sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->