### PR TITLE
feat: bluesky rss/atom

### DIFF
--- a/src/helpers/syndicationFeeds.ts
+++ b/src/helpers/syndicationFeeds.ts
@@ -1,5 +1,8 @@
-import type { APITwitterStatus, APIVideo } from '../realms/api/schemas';
+import type { APIBlueskyStatus, APITwitterStatus, APIVideo } from '../realms/api/schemas';
 import { truncateWithEllipsis } from './utils';
+
+/** Twitter or Bluesky API v2–shaped status for RSS/Atom item mapping. */
+export type SyndicationStatus = APITwitterStatus | APIBlueskyStatus;
 
 export type SyndicationFeedMeta = {
   channelTitle: string;
@@ -53,7 +56,7 @@ const toRfc822 = (d: Date): string => d.toUTCString();
 const toIso8601 = (d: Date): string => d.toISOString();
 
 /** Unified media ordering (matches HTML body). */
-export function statusMediaList(status: APITwitterStatus) {
+export function statusMediaList(status: SyndicationStatus) {
   const m = status.media;
   if (m?.all?.length) return m.all;
   return [...(m?.photos ?? []), ...(m?.videos ?? [])];
@@ -108,7 +111,7 @@ function pickProgressiveVideoUrl(v: APIVideo): { url: string; mime: string } | n
  * else external embed thumbnail, else link-card image.
  */
 export function syndicationEnclosureFromStatus(
-  status: APITwitterStatus
+  status: SyndicationStatus
 ): SyndicationEnclosure | undefined {
   const first = statusMediaList(status)[0];
   if (first) {
@@ -150,20 +153,22 @@ export function syndicationEnclosureFromStatus(
     };
   }
 
-  const cardImg = status.card?.image?.url;
-  if (cardImg) {
-    return {
-      url: cardImg,
-      type: mimeForImageUrl(cardImg),
-      length: 0
-    };
+  if (status.provider === 'twitter') {
+    const cardImg = status.card?.image?.url;
+    if (cardImg) {
+      return {
+        url: cardImg,
+        type: mimeForImageUrl(cardImg),
+        length: 0
+      };
+    }
   }
 
   return undefined;
 }
 
 function buildItemHtml(
-  status: APITwitterStatus,
+  status: SyndicationStatus,
   options: { omitSensitive?: boolean } = {}
 ): string {
   const body = escapeXml(status.text).replace(/\n/g, '<br />\n');
@@ -194,7 +199,7 @@ function buildItemHtml(
 }
 
 export function statusesToFeedItems(
-  statuses: APITwitterStatus[],
+  statuses: SyndicationStatus[],
   options: { omitSensitive?: boolean }
 ): SyndicationFeedItem[] {
   const out: SyndicationFeedItem[] = [];

--- a/src/providers/bluesky/profileStatuses.ts
+++ b/src/providers/bluesky/profileStatuses.ts
@@ -5,7 +5,8 @@ import type {
   APIRepostedBy,
   APIGroupedSearchResultsBluesky,
   APISearchResultsBluesky,
-  TimelineEntryBluesky
+  TimelineEntryBluesky,
+  TimelineThreadBluesky
 } from '../../realms/api/schemas';
 import { buildAPIBlueskyPost } from './processor';
 import { fetchActorLikes, fetchAuthorFeed } from './client';
@@ -218,6 +219,178 @@ export const blueskyProfileMediaAPI = async (
     },
     c
   );
+
+/** Max author-feed pages to merge for RSS (aligns with Twitter profile feed pagination). */
+const BLUESKY_PROFILE_FEED_MAX_PAGES = 10;
+
+const BLUESKY_PROFILE_FEED_PER_PAGE = 100;
+
+const BLUESKY_PROFILE_FEED_TARGET_CAP = 100;
+
+function isBlueskyFlatStatus(
+  r: APIBlueskyStatus | TimelineThreadBluesky
+): r is APIBlueskyStatus {
+  return r.type === 'status';
+}
+
+/**
+ * Fetches up to `maxTotal` posts (cap 100) by walking `cursor.bottom` across
+ * multiple `blueskyProfileStatusesAPI` calls. Dedupes by post `id`. Uses a flat
+ * timeline (`groupThreads: false`).
+ */
+export const blueskyProfileStatusesAPIPaginated = async (
+  actor: string,
+  maxTotal: number,
+  c: Context,
+  withReplies = false,
+  language?: string
+): Promise<APISearchResultsBluesky> => {
+  const target = Math.min(BLUESKY_PROFILE_FEED_TARGET_CAP, Math.max(1, maxTotal));
+  const merged: APIBlueskyStatus[] = [];
+  const seenIds = new Set<string>();
+  let cursor: string | null = null;
+  let lastCursors: APISearchResultsBluesky['cursor'] = { top: null, bottom: null };
+  let pages = 0;
+  let anySuccessfulPage = false;
+
+  while (merged.length < target && pages < BLUESKY_PROFILE_FEED_MAX_PAGES) {
+    pages += 1;
+    const page = await blueskyProfileStatusesAPI(
+      actor,
+      {
+        count: BLUESKY_PROFILE_FEED_PER_PAGE,
+        cursor,
+        withReplies,
+        language,
+        groupThreads: false
+      },
+      c
+    );
+
+    if (page.code === 404) {
+      if (merged.length === 0) {
+        return { code: 404, results: [], cursor: { top: null, bottom: null } };
+      }
+      break;
+    }
+
+    if (page.code !== 200) {
+      if (merged.length === 0) {
+        return { code: page.code, results: [], cursor: { top: null, bottom: null } };
+      }
+      break;
+    }
+
+    anySuccessfulPage = true;
+    lastCursors = page.cursor;
+
+    if (page.results.length === 0) {
+      break;
+    }
+
+    for (const r of page.results as TimelineEntryBluesky[]) {
+      if (!isBlueskyFlatStatus(r)) continue;
+      if (seenIds.has(r.id)) continue;
+      seenIds.add(r.id);
+      merged.push(r);
+      if (merged.length >= target) break;
+    }
+
+    if (merged.length >= target) break;
+
+    const bottom = page.cursor.bottom;
+    if (!bottom || bottom === cursor) break;
+    cursor = bottom;
+  }
+
+  if (merged.length === 0) {
+    if (anySuccessfulPage) {
+      return { code: 200, results: [], cursor: { top: null, bottom: null } };
+    }
+    return { code: 404, results: [], cursor: { top: null, bottom: null } };
+  }
+
+  return {
+    code: 200,
+    results: merged.slice(0, target),
+    cursor: lastCursors
+  };
+};
+
+/**
+ * Same pagination strategy as `blueskyProfileStatusesAPIPaginated`, for the
+ * profile media filter (`posts_with_media`).
+ */
+export const blueskyProfileMediaAPIPaginated = async (
+  actor: string,
+  maxTotal: number,
+  c: Context,
+  language?: string
+): Promise<APISearchResultsBluesky> => {
+  const target = Math.min(BLUESKY_PROFILE_FEED_TARGET_CAP, Math.max(1, maxTotal));
+  const merged: APIBlueskyStatus[] = [];
+  const seenIds = new Set<string>();
+  let cursor: string | null = null;
+  let lastCursors: APISearchResultsBluesky['cursor'] = { top: null, bottom: null };
+  let pages = 0;
+  let anySuccessfulPage = false;
+
+  while (merged.length < target && pages < BLUESKY_PROFILE_FEED_MAX_PAGES) {
+    pages += 1;
+    const page = await blueskyProfileMediaAPI(
+      actor,
+      { count: BLUESKY_PROFILE_FEED_PER_PAGE, cursor, language },
+      c
+    );
+
+    if (page.code === 404) {
+      if (merged.length === 0) {
+        return { code: 404, results: [], cursor: { top: null, bottom: null } };
+      }
+      break;
+    }
+
+    if (page.code !== 200) {
+      if (merged.length === 0) {
+        return { code: page.code, results: [], cursor: { top: null, bottom: null } };
+      }
+      break;
+    }
+
+    anySuccessfulPage = true;
+    lastCursors = page.cursor;
+
+    if (page.results.length === 0) {
+      break;
+    }
+
+    for (const r of page.results) {
+      if (seenIds.has(r.id)) continue;
+      seenIds.add(r.id);
+      merged.push(r);
+      if (merged.length >= target) break;
+    }
+
+    if (merged.length >= target) break;
+
+    const bottom = page.cursor.bottom;
+    if (!bottom || bottom === cursor) break;
+    cursor = bottom;
+  }
+
+  if (merged.length === 0) {
+    if (anySuccessfulPage) {
+      return { code: 200, results: [], cursor: { top: null, bottom: null } };
+    }
+    return { code: 404, results: [], cursor: { top: null, bottom: null } };
+  }
+
+  return {
+    code: 200,
+    results: merged.slice(0, target),
+    cursor: lastCursors
+  };
+};
 
 export const blueskyProfileLikesAPI = async (
   actor: string,

--- a/src/providers/bluesky/profileStatuses.ts
+++ b/src/providers/bluesky/profileStatuses.ts
@@ -227,9 +227,7 @@ const BLUESKY_PROFILE_FEED_PER_PAGE = 100;
 
 const BLUESKY_PROFILE_FEED_TARGET_CAP = 100;
 
-function isBlueskyFlatStatus(
-  r: APIBlueskyStatus | TimelineThreadBluesky
-): r is APIBlueskyStatus {
+function isBlueskyFlatStatus(r: APIBlueskyStatus | TimelineThreadBluesky): r is APIBlueskyStatus {
   return r.type === 'status';
 }
 

--- a/src/realms/bluesky/router.ts
+++ b/src/realms/bluesky/router.ts
@@ -6,6 +6,12 @@ import { versionRoute } from '../common/version';
 import { genericBlueskyRedirect } from './routes/redirects';
 import { activityRequest } from './routes/activity';
 import { getBranding } from '../../helpers/branding';
+import {
+  profileFeedAtomBluesky,
+  profileFeedRssBluesky,
+  profileMediaFeedAtomBluesky,
+  profileMediaFeedRssBluesky
+} from './routes/feed';
 
 export const bluesky = new Hono();
 
@@ -16,6 +22,10 @@ bluesky.get('/:prefix/:handle/post/:id', blueskyStatusRequest);
 bluesky.get('/profile/:handle/post/:id', blueskyStatusRequest);
 bluesky.get('/:prefix/profile/:handle/post/:id/:language', blueskyStatusRequest);
 bluesky.get('/profile/:handle/post/:id/:language', blueskyStatusRequest);
+bluesky.get('/profile/:handle/feed.xml', profileFeedRssBluesky);
+bluesky.get('/profile/:handle/feed.atom.xml', profileFeedAtomBluesky);
+bluesky.get('/profile/:handle/media.xml', profileMediaFeedRssBluesky);
+bluesky.get('/profile/:handle/media.atom.xml', profileMediaFeedAtomBluesky);
 bluesky.get('/profile/*', genericBlueskyRedirect);
 bluesky.get('/version', c => versionRoute(c));
 

--- a/src/realms/bluesky/routes/feed.ts
+++ b/src/realms/bluesky/routes/feed.ts
@@ -1,0 +1,204 @@
+import { Context } from 'hono';
+import { ContentfulStatusCode } from 'hono/utils/http-status';
+import type { APIBlueskyStatus } from '../../../realms/api/schemas';
+import {
+  blueskyProfileMediaAPIPaginated,
+  blueskyProfileStatusesAPIPaginated
+} from '../../../providers/bluesky/profileStatuses';
+import { isParamTruthy } from '../../../helpers/utils';
+import {
+  statusesToFeedItems,
+  toAtomFeedXml,
+  toRss20Xml,
+  type SyndicationFeedMeta
+} from '../../../helpers/syndicationFeeds';
+import { getBranding } from '../../../helpers/branding';
+
+const DEFAULT_FEED_COUNT = 90;
+const FEED_CACHE_CONTROL = 'public, max-age=120';
+
+type SyndicationFeedKind = 'timeline' | 'media';
+
+function clampCount(raw: string | undefined): number {
+  const n = raw === undefined ? DEFAULT_FEED_COUNT : parseInt(raw, 10);
+  if (Number.isNaN(n)) return DEFAULT_FEED_COUNT;
+  return Math.min(100, Math.max(1, n));
+}
+
+function feedRequestLanguage(c: Context): string | undefined {
+  const q = c.req.query();
+  const raw = q.lang ?? q.language;
+  if (typeof raw !== 'string' || raw.length === 0) return undefined;
+  return raw;
+}
+
+function parseFeedQuery(c: Context): {
+  count: number;
+  withReplies: boolean;
+  safe: boolean;
+  language?: string;
+} {
+  const q = c.req.query();
+  const language = feedRequestLanguage(c);
+  return {
+    count: clampCount(q.count),
+    withReplies: isParamTruthy(q.with_replies ?? q.withReplies),
+    safe: isParamTruthy(q.safe),
+    ...(language ? { language } : {})
+  };
+}
+
+function parseMediaFeedQuery(c: Context): { count: number; safe: boolean; language?: string } {
+  const q = c.req.query();
+  const language = feedRequestLanguage(c);
+  return {
+    count: clampCount(q.count),
+    safe: isParamTruthy(q.safe),
+    ...(language ? { language } : {})
+  };
+}
+
+function feedAuthorName(handle: string, results: APIBlueskyStatus[]): string {
+  const screen = handle.replace(/^@/, '');
+  const fromPost = results.find(s => s.author?.name?.trim())?.author?.name?.trim();
+  return fromPost ?? `@${screen}`;
+}
+
+function feedChannelTitle(handle: string, results: APIBlueskyStatus[]): string {
+  const screenFromUrl = handle.replace(/^@/, '').toLowerCase();
+  const authorForProfile =
+    results.find(
+      s => s.author && s.author.screen_name.replace(/^@/, '').toLowerCase() === screenFromUrl
+    )?.author ?? results.find(s => s.author)?.author;
+
+  const screen = (authorForProfile?.screen_name ?? handle.replace(/^@/, '')).replace(/^@/, '');
+  const atScreen = `@${screen}`;
+  const displayName = authorForProfile?.name?.trim();
+  return displayName ? `${displayName} (${atScreen})` : atScreen;
+}
+
+function feedChannelImageUrl(results: APIBlueskyStatus[]): string | undefined {
+  const url = results.find(s => s.author?.avatar_url)?.author?.avatar_url;
+  return url ?? undefined;
+}
+
+function newestUnfilteredStatusDate(results: APIBlueskyStatus[]): Date | undefined {
+  if (results.length === 0) return undefined;
+  return new Date(Math.max(...results.map(s => s.created_timestamp * 1000)));
+}
+
+function buildMeta(
+  c: Context,
+  handle: string,
+  kind: SyndicationFeedKind,
+  results: APIBlueskyStatus[]
+): SyndicationFeedMeta {
+  const requestUrl = new URL(c.req.url);
+  const origin = requestUrl.origin;
+  const qs = requestUrl.search;
+  const branding = getBranding(c);
+  const enc = encodeURIComponent(handle);
+  const profileWebUrl = `${origin}/profile/${enc}${qs}`;
+  const authorName = feedAuthorName(handle, results);
+  const channelTitle = feedChannelTitle(handle, results);
+  const channelImageUrl = feedChannelImageUrl(results);
+
+  if (kind === 'media') {
+    const selfUrlRss = `${origin}/profile/${enc}/media.xml${qs}`;
+    const selfUrlAtom = `${origin}/profile/${enc}/media.atom.xml${qs}`;
+    return {
+      channelTitle,
+      channelDescription: `Media from @${handle} via ${branding.name}.`,
+      profileWebUrl,
+      selfUrlRss,
+      selfUrlAtom,
+      authorName,
+      ...(channelImageUrl ? { channelImageUrl } : {})
+    };
+  }
+
+  const selfUrlRss = `${origin}/profile/${enc}/feed.xml${qs}`;
+  const selfUrlAtom = `${origin}/profile/${enc}/feed.atom.xml${qs}`;
+
+  return {
+    channelTitle,
+    channelDescription: `Posts by @${handle}`,
+    profileWebUrl,
+    selfUrlRss,
+    selfUrlAtom,
+    authorName,
+    ...(channelImageUrl ? { channelImageUrl } : {})
+  };
+}
+
+async function serveFeed(
+  c: Context,
+  handle: string | undefined,
+  format: 'rss' | 'atom',
+  kind: SyndicationFeedKind
+): Promise<Response> {
+  if (!handle) {
+    c.header('Cache-Control', 'no-store');
+    return c.body('', 404);
+  }
+
+  let apiResult: Awaited<ReturnType<typeof blueskyProfileStatusesAPIPaginated>>;
+  let omitSensitive: boolean;
+
+  if (kind === 'timeline') {
+    const q = parseFeedQuery(c);
+    omitSensitive = q.safe;
+    apiResult = await blueskyProfileStatusesAPIPaginated(
+      handle,
+      q.count,
+      c,
+      q.withReplies,
+      q.language
+    );
+  } else {
+    const q = parseMediaFeedQuery(c);
+    omitSensitive = q.safe;
+    apiResult = await blueskyProfileMediaAPIPaginated(handle, q.count, c, q.language);
+  }
+
+  const meta = buildMeta(c, handle, kind, apiResult.results);
+  const items = statusesToFeedItems(apiResult.results, { omitSensitive });
+  const feedUpdatedFallback = omitSensitive
+    ? newestUnfilteredStatusDate(apiResult.results)
+    : undefined;
+
+  c.header('Access-Control-Allow-Origin', '*');
+
+  if (apiResult.code === 404) {
+    c.header('Cache-Control', 'no-store');
+    return c.body('', 404);
+  }
+
+  if (apiResult.code !== 200) {
+    c.header('Cache-Control', 'no-store');
+    return c.body('', apiResult.code as ContentfulStatusCode);
+  }
+
+  const contentType =
+    format === 'rss' ? 'application/rss+xml; charset=utf-8' : 'application/atom+xml; charset=utf-8';
+  c.header('Content-Type', contentType);
+  c.header('Cache-Control', FEED_CACHE_CONTROL);
+
+  const xml =
+    format === 'rss'
+      ? toRss20Xml(meta, items, feedUpdatedFallback)
+      : toAtomFeedXml(meta, items, feedUpdatedFallback);
+  return c.body(xml, 200);
+}
+
+export const profileFeedRssBluesky = (c: Context) =>
+  serveFeed(c, c.req.param('handle'), 'rss', 'timeline');
+
+export const profileFeedAtomBluesky = (c: Context) =>
+  serveFeed(c, c.req.param('handle'), 'atom', 'timeline');
+
+export const profileMediaFeedRssBluesky = (c: Context) =>
+  serveFeed(c, c.req.param('handle'), 'rss', 'media');
+
+export const profileMediaFeedAtomBluesky = (c: Context) =>
+  serveFeed(c, c.req.param('handle'), 'atom', 'media');

--- a/test/bluesky.feeds.test.ts
+++ b/test/bluesky.feeds.test.ts
@@ -1,0 +1,96 @@
+import { test, expect, vi, afterEach } from 'vitest';
+import { app } from '../src/worker';
+import { botHeaders } from './helpers/data';
+import harness from './helpers/harness';
+import authorFeed from './fixtures/bluesky/author-feed.json';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test('Bluesky realm serves RSS for profile feed.xml', async () => {
+  vi.spyOn(globalThis, 'fetch').mockImplementation(async (input: RequestInfo) => {
+    const u = typeof input === 'string' ? input : input.url;
+    if (u.includes('app.bsky.feed.getAuthorFeed')) {
+      return new Response(JSON.stringify(authorFeed), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+    throw new Error(`Unexpected fetch: ${u}`);
+  });
+
+  const res = await app.request(
+    new Request('https://fxbsky.app/profile/author.test/feed.xml', {
+      method: 'GET',
+      headers: botHeaders
+    }),
+    undefined,
+    harness
+  );
+  expect(res.status).toBe(200);
+  expect(res.headers.get('content-type')).toContain('application/rss+xml');
+  const text = await res.text();
+  expect(text).toContain('<rss version="2.0"');
+  expect(text).toContain('<atom:link');
+  expect(text).toContain('rel="self"');
+  expect(text).toContain('/profile/author.test/feed.xml');
+  expect(text).toMatch(/post\/rkey/);
+});
+
+test('Bluesky realm serves Atom for profile feed.atom.xml', async () => {
+  vi.spyOn(globalThis, 'fetch').mockImplementation(async (input: RequestInfo) => {
+    const u = typeof input === 'string' ? input : input.url;
+    if (u.includes('app.bsky.feed.getAuthorFeed')) {
+      return new Response(JSON.stringify(authorFeed), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+    throw new Error(`Unexpected fetch: ${u}`);
+  });
+
+  const res = await app.request(
+    new Request('https://fxbsky.app/profile/author.test/feed.atom.xml', {
+      method: 'GET',
+      headers: botHeaders
+    }),
+    undefined,
+    harness
+  );
+  expect(res.status).toBe(200);
+  expect(res.headers.get('content-type')).toContain('application/atom+xml');
+  const text = await res.text();
+  expect(text).toContain('xmlns="http://www.w3.org/2005/Atom"');
+  expect(text).toContain('rel="self"');
+  expect(text).toContain('/profile/author.test/feed.atom.xml');
+});
+
+test('Bluesky realm serves RSS for profile media.xml', async () => {
+  vi.spyOn(globalThis, 'fetch').mockImplementation(async (input: RequestInfo) => {
+    const u = typeof input === 'string' ? input : input.url;
+    if (u.includes('app.bsky.feed.getAuthorFeed')) {
+      expect(u).toContain('filter=posts_with_media');
+      return new Response(JSON.stringify(authorFeed), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+    throw new Error(`Unexpected fetch: ${u}`);
+  });
+
+  const res = await app.request(
+    new Request('https://fxbsky.app/profile/author.test/media.xml', {
+      method: 'GET',
+      headers: botHeaders
+    }),
+    undefined,
+    harness
+  );
+  expect(res.status).toBe(200);
+  expect(res.headers.get('content-type')).toContain('application/rss+xml');
+  const text = await res.text();
+  expect(text).toContain('<rss version="2.0"');
+  expect(text).toContain('/profile/author.test/media.xml');
+  expect(text).toContain('rel="self"');
+});

--- a/test/syndicationFeeds.test.ts
+++ b/test/syndicationFeeds.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from 'vitest';
-import type { APITwitterStatus } from '../src/realms/api/schemas';
+import type { APIBlueskyStatus, APITwitterStatus } from '../src/realms/api/schemas';
 import {
   escapeXml,
   statusesToFeedItems,
@@ -254,4 +254,47 @@ test('tweet text with angle brackets is escaped inside CDATA-wrapped HTML', () =
   expect(xml).toContain('<![CDATA[');
   expect(xml).toContain(']]&gt;');
   expect(xml).not.toMatch(/\]\]>\s*b/);
+});
+
+const baseBlueskyStatus = (over: Partial<APIBlueskyStatus> = {}): APIBlueskyStatus =>
+  ({
+    id: 'rkeybsky',
+    cid: 'bafycidbsky',
+    url: 'https://bsky.app/profile/handle.test/post/rkeybsky',
+    text: 'Hello from ATProto',
+    created_at: '2024-01-01T00:00:00.000Z',
+    created_timestamp: 1704067200,
+    likes: 0,
+    reposts: 0,
+    replies: 0,
+    author: {
+      ...baseStatus().author,
+      type: 'profile',
+      id: 'handle.test',
+      name: 'Handle',
+      screen_name: 'handle.test',
+      url: 'https://bsky.app/profile/handle.test',
+      profile_embed: true
+    },
+    media: { photos: [], videos: [] },
+    raw_text: { text: 'Hello from ATProto', facets: [] },
+    lang: 'en',
+    possibly_sensitive: false,
+    replying_to: null,
+    source: 'Bluesky Social',
+    embed_card: 'tweet',
+    provider: 'bluesky',
+    type: 'status',
+    ...over
+  }) as APIBlueskyStatus;
+
+test('statusesToFeedItems accepts APIBlueskyStatus and emits RSS item link', () => {
+  const s = baseBlueskyStatus();
+  const items = statusesToFeedItems([s], {});
+  expect(items).toHaveLength(1);
+  expect(items[0].url).toBe('https://bsky.app/profile/handle.test/post/rkeybsky');
+  const xml = toRss20Xml(mockMeta, items);
+  expect(xml).toContain(
+    '<guid isPermaLink="true">https://bsky.app/profile/handle.test/post/rkeybsky</guid>'
+  );
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bluesky profile feeds available in RSS and Atom at profile feed and media endpoints
  * Media-only feed endpoints and query options: count (1–100), with_replies, safe, language

* **Bug Fixes**
  * Improved media/enclosure selection so non-Twitter posts no longer attempt Twitter-specific image paths

* **Tests**
  * Added tests validating Bluesky feed endpoints and feed item generation for Bluesky posts
<!-- end of auto-generated comment: release notes by coderabbit.ai -->