### PR TITLE
docs: RSS/Atom feeds for Bluesky profiles

### DIFF
--- a/docs/src/content/docs/guide/advanced/rss-atom-feeds.mdx
+++ b/docs/src/content/docs/guide/advanced/rss-atom-feeds.mdx
@@ -1,13 +1,15 @@
 ---
 title: RSS & Atom feeds
-description: Subscribe to X/Twitter profiles with RSS 2.0 or Atom from FxTwitter and FixupX.
+description: Subscribe to X/Twitter and Bluesky profiles with RSS 2.0 or Atom from FxTwitter, FixupX, and FxBluesky.
 ---
 
-FxEmbed exposes **RSS 2.0** and **Atom** feeds for X/Twitter profiles. Use them in feed readers, automation, or any client that polls syndication URLs.
+FxEmbed exposes **RSS 2.0** and **Atom** feeds for **X/Twitter** and **Bluesky** profiles. Use them in feed readers, automation, or any client that polls syndication URLs.
 
-Many readers can automatically detect the feed from an FxTwitter / FixupX link, but if not, you can also manually add and customize the feed you want to your reader.
+Many readers can automatically detect the feed from an FxTwitter / FixupX / FxBluesky link, but if not, you can also manually add and customize the feed you want to your reader.
 
 ## Feed URLs
+
+### X / Twitter (FxTwitter, FixupX, …)
 
 | Format   | All Recent Posts                               |
 | -------- | ---------------------------------------------- |
@@ -19,6 +21,24 @@ Many readers can automatically detect the feed from an FxTwitter / FixupX link, 
 | **RSS**  | `https://fxtwitter.com/{handle}/media.xml`      |
 | **Atom** | `https://fxtwitter.com/{handle}/media.atom.xml` |
 
+Replace the host with your deployment’s X realm (for example `fixupx.com` for `x.com` links).
+
+### Bluesky (FxBluesky)
+
+Paths use `/profile/` before the handle, matching other FxBluesky profile URLs.
+
+| Format   | All Recent Posts                                                   |
+| -------- | ------------------------------------------------------------------ |
+| **RSS**  | `https://fxbsky.app/profile/{handle}/feed.xml`                     |
+| **Atom** | `https://fxbsky.app/profile/{handle}/feed.atom.xml`                |
+
+| Format   | Media-only Posts                                                  |
+| -------- | ----------------------------------------------------------------- |
+| **RSS**  | `https://fxbsky.app/profile/{handle}/media.xml`                   |
+| **Atom** | `https://fxbsky.app/profile/{handle}/media.atom.xml`              |
+
+`{handle}` is the Bluesky handle (for example `user.bsky.social`), with or without a leading `@` in the path segment.
+
 - **Timeline feeds** include recent posts (original posts and reposts as returned by the profile timeline API).
 - **Media feeds** only include posts that have photos or videos—useful if you want a gallery-style stream.
 
@@ -29,21 +49,27 @@ All parameters are optional.
 | Parameter                       | Applies to         | Description                                                                               |
 | ------------------------------- | ------------------ | ----------------------------------------------------------------------------------------- |
 | `count`                         | Timeline and media | Number of items to fetch, **1–100** (default **90**).                                     |
-| `with_replies` or `withReplies` | Timeline only      | Include reply posts                                                                       |
+| `with_replies` or `withReplies` | Timeline only      | Include reply posts.                                                                    |
 | `safe`                          | Timeline and media | Hides posts (and quoted bodies) marked sensitive.                                         |
 | `lang` or `language`            | Timeline and media | Requests for automatic translation of content when available. Currently it's a bit iffy whether it works or not, so don't be surprised if things aren't translated just yet. |
 
-Example:
+Example (X):
 
 ```
 https://fxtwitter.com/example/feed.xml?count=50&safe=1
+```
+
+Example (Bluesky):
+
+```
+https://fxbsky.app/profile/user.bsky.social/feed.xml?count=50&safe=1
 ```
 
 Query strings are preserved in the feed’s self-link metadata so subscribers and validators see a stable identity per URL variant.
 
 ## What readers get
 
-- **RSS** is RSS 2.0 with an Atom `rel="self"` link, `guid` per item (permalink to the post on X), and HTML `description` content (CDATA). Video items use **Media RSS** (`media:thumbnail`) when a poster image exists.
+- **RSS** is RSS 2.0 with an Atom `rel="self"` link, `guid` per item (permalink to the post on X or Bluesky), and HTML `description` content (CDATA). Video items use **Media RSS** (`media:thumbnail`) when a poster image exists.
 - **Atom** is RFC 4287 with `content type="html"` entries and a feed-level author when a display name is available.
 - **Channel artwork**: profile avatar is exposed as RSS `<image>` and Atom `<icon>` when present.
 - **Enclosures**: the first suitable attachment is attached as `enclosure` / `rel="enclosure"`—photos and GIFs as images, videos as **progressive MP4** (not HLS) when available. If a post has no media but has a link preview card with an image, that image may be used as the enclosure.

--- a/docs/src/content/docs/guide/compare.mdx
+++ b/docs/src/content/docs/guide/compare.mdx
@@ -28,8 +28,6 @@ description: Compare FxEmbed features with other alternatives.
 | RSS & Atom feeds                       |                 ✅                 |   N/A   |               ❌               |
 | Last commit                            |           [![][flc]][fc]           |   N/A   |         [![][vlc]][vc]         |
 
-RSS and Atom feeds are available for X/Twitter and Bluesky profiles; see [RSS & Atom feeds](/guide/advanced/rss-atom-feeds/).
-
 [flc]: https://img.shields.io/github/last-commit/FxEmbed/FxEmbed?label
 [vlc]: https://img.shields.io/github/last-commit/dylanpdx/BetterTwitFix?label
 [fc]: https://github.com/FxEmbed/FxEmbed/commits

--- a/docs/src/content/docs/guide/compare.mdx
+++ b/docs/src/content/docs/guide/compare.mdx
@@ -28,6 +28,8 @@ description: Compare FxEmbed features with other alternatives.
 | RSS & Atom feeds                       |                 ✅                 |   N/A   |               ❌               |
 | Last commit                            |           [![][flc]][fc]           |   N/A   |         [![][vlc]][vc]         |
 
+RSS and Atom feeds are available for X/Twitter and Bluesky profiles; see [RSS & Atom feeds](/guide/advanced/rss-atom-feeds/).
+
 [flc]: https://img.shields.io/github/last-commit/FxEmbed/FxEmbed?label
 [vlc]: https://img.shields.io/github/last-commit/dylanpdx/BetterTwitFix?label
 [fc]: https://github.com/FxEmbed/FxEmbed/commits


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the docs site so syndication feeds describe both X/Twitter and Bluesky (FxTwitter/FixupX vs FxBluesky URL patterns).

## Changes

- **RSS & Atom feeds** (`docs/src/content/docs/guide/advanced/rss-atom-feeds.mdx`): Front matter and intro cover FxBluesky; split URL tables for X vs Bluesky under `/profile/`; Bluesky query example; item permalinks described for X or Bluesky.

## Verification

- `cd docs && npm install && npm run build` succeeds.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fb17fa86-fb14-4b84-8d97-ada2a5aefc75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb17fa86-fb14-4b84-8d97-ada2a5aefc75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded RSS and Atom feeds guide to include Bluesky profiles alongside X/Twitter
  * Added Bluesky-specific feed URL patterns, examples, and handle formatting guidance
  * Updated comparison guide to reference available feed sources

<!-- end of auto-generated comment: release notes by coderabbit.ai -->