### PR TITLE
FxBluesky: expose verification with verified_by

### DIFF
--- a/src/providers/bluesky/processor.ts
+++ b/src/providers/bluesky/processor.ts
@@ -10,32 +10,38 @@ import { unescapeText } from '../../helpers/utils';
 import { blueskyFacetsToApiFacets } from './facets';
 import { type BlueskyFetchOpts, fetchPostsByUris, fetchProfilesByActors } from './client';
 import { blueskyWebPostUrl, didFromAtUri, rkeyFromPostAtUri } from './uris';
+import { blueskyVerificationToApiUserVerification } from './verification';
 
 const isPossiblySensitive = (labels: ATProtoLabel[] | undefined | null): boolean =>
   !!labels?.some(l => /nsfw|porn|sexual|nudity|graphic|!warn/i.test(l.val ?? ''));
 
-const apiUserFromAuthor = (author: BlueskyAuthor): APIUser => ({
-  id: author.handle,
-  name: author.displayName || author.handle,
-  screen_name: author.handle,
-  avatar_url: author.avatar ?? null,
-  banner_url: null,
-  description: '',
-  raw_description: { text: '', facets: [] },
-  location: '',
-  followers: 0,
-  following: 0,
-  media_count: 0,
-  likes: 0,
-  url: `${Constants.BLUESKY_ROOT}/profile/${author.handle}`,
-  protected: false,
-  statuses: 0,
-  joined: author.createdAt,
-  birthday: { day: 0, month: 0, year: 0 },
-  website: null,
-  profile_embed: true,
-  type: 'profile'
-});
+const apiUserFromAuthor = (author: BlueskyAuthor): APIUser => {
+  const base: APIUser = {
+    id: author.handle,
+    name: author.displayName || author.handle,
+    screen_name: author.handle,
+    avatar_url: author.avatar ?? null,
+    banner_url: null,
+    description: '',
+    raw_description: { text: '', facets: [] },
+    location: '',
+    followers: 0,
+    following: 0,
+    media_count: 0,
+    likes: 0,
+    url: `${Constants.BLUESKY_ROOT}/profile/${author.handle}`,
+    protected: false,
+    statuses: 0,
+    joined: author.createdAt,
+    birthday: { day: 0, month: 0, year: 0 },
+    website: null,
+    profile_embed: true,
+    type: 'profile'
+  };
+  const v = blueskyVerificationToApiUserVerification(author.verification);
+  if (v) base.verification = v;
+  return base;
+};
 
 const tombstoneAuthor = (handleOrDid: string): APIUser => ({
   id: handleOrDid,

--- a/src/providers/bluesky/profile.ts
+++ b/src/providers/bluesky/profile.ts
@@ -5,6 +5,7 @@ import type { APIUser, UserAPIResponse } from '../../realms/api/schemas';
 import { blueskyFacetsToApiFacets } from './facets';
 import { detectBlueskyDescriptionFacets } from './detectDescriptionFacets';
 import { fetchActorProfile } from './client';
+import { blueskyVerificationToApiUserVerification } from './verification';
 
 export const blueskyProfileToApiUser = (profile: BlueskyProfileViewDetailed): APIUser => {
   const handle = profile.handle;
@@ -41,13 +42,8 @@ export const blueskyProfileToApiUser = (profile: BlueskyProfileViewDetailed): AP
     type: 'profile'
   };
 
-  if (profile.verification?.verifiedStatus === 'valid') {
-    apiUser.verification = {
-      verified: true,
-      type: null,
-      verified_at: null
-    };
-  }
+  const v = blueskyVerificationToApiUserVerification(profile.verification);
+  if (v) apiUser.verification = v;
 
   return apiUser;
 };

--- a/src/providers/bluesky/profileFollowers.ts
+++ b/src/providers/bluesky/profileFollowers.ts
@@ -4,6 +4,7 @@ import { linkFixerBluesky } from '../../helpers/linkFixer';
 import type { APIProfileRelationshipList, APIUser } from '../../realms/api/schemas';
 import { fetchFollowers, fetchFollows, fetchProfilesDetailedBatched } from './client';
 import { blueskyProfileToApiUser } from './profile';
+import { blueskyVerificationToApiUserVerification } from './verification';
 
 const relationshipListNotFound = (): APIProfileRelationshipList => ({
   code: 404,
@@ -49,13 +50,8 @@ export const blueskyProfileViewToApiUser = (view: BlueskyProfileView): APIUser =
     type: 'profile'
   };
 
-  if (view.verification?.verifiedStatus === 'valid') {
-    apiUser.verification = {
-      verified: true,
-      type: null,
-      verified_at: null
-    };
-  }
+  const v = blueskyVerificationToApiUserVerification(view.verification);
+  if (v) apiUser.verification = v;
 
   return apiUser;
 };

--- a/src/providers/bluesky/verification.ts
+++ b/src/providers/bluesky/verification.ts
@@ -1,0 +1,55 @@
+import type { APIUser } from '../../realms/api/schemas';
+
+/** DID for the official `bsky.app` account (`alsoKnownAs` includes `at://bsky.app`). */
+export const BLUESKY_APP_OFFICIAL_ISSUER_DID = 'did:plc:z72i7hdynmk6r22z27h6tvur';
+
+type BlueskyVerificationViewSubset = {
+  issuer?: string;
+  isValid?: boolean;
+};
+
+type BlueskyVerificationStateSubset = {
+  verifiedStatus?: string;
+  verifications?: BlueskyVerificationViewSubset[];
+};
+
+const validIssuers = (state: BlueskyVerificationStateSubset | undefined): string[] => {
+  const list = state?.verifications;
+  if (!list?.length) return [];
+  return list.filter(v => v.isValid === true && typeof v.issuer === 'string').map(v => v.issuer!);
+};
+
+/**
+ * Maps `app.bsky.actor.defs#verificationState` into API `verification` for FxBluesky.
+ * Uses `verified_by` (`bsky.app`, another issuer DID, or `trusted_verifier`) instead of X-style `type`.
+ */
+export const blueskyVerificationToApiUserVerification = (
+  state: BlueskyVerificationStateSubset | undefined
+): NonNullable<APIUser['verification']> | undefined => {
+  if (state?.verifiedStatus !== 'valid') return undefined;
+
+  const issuers = validIssuers(state);
+  const official = issuers.find(i => i === BLUESKY_APP_OFFICIAL_ISSUER_DID);
+  if (official) {
+    return {
+      verified: true,
+      type: null,
+      verified_at: null,
+      verified_by: 'bsky.app'
+    };
+  }
+  if (issuers[0]) {
+    return {
+      verified: true,
+      type: null,
+      verified_at: null,
+      verified_by: issuers[0]
+    };
+  }
+  return {
+    verified: true,
+    type: null,
+    verified_at: null,
+    verified_by: 'trusted_verifier'
+  };
+};

--- a/src/realms/api/schemas.ts
+++ b/src/realms/api/schemas.ts
@@ -160,7 +160,9 @@ export const APIUserSchema = z
         verified: z.boolean(),
         type: z.enum(['organization', 'government', 'individual']).nullable(),
         verified_at: z.string().nullable().optional(),
-        identity_verified: z.boolean().optional()
+        identity_verified: z.boolean().optional(),
+        /** Bluesky: issuer handle (`bsky.app`), issuer DID, or `trusted_verifier` when upstream omits `verifications`. */
+        verified_by: z.string().optional()
       })
       .optional(),
     about_account: APIAboutAccountSchema.optional(),

--- a/src/types/vendor/bluesky.d.ts
+++ b/src/types/vendor/bluesky.d.ts
@@ -106,6 +106,11 @@ declare type BlueskyAuthor = {
   displayName: string;
   handle: string;
   labels: ATProtoLabel[];
+  verification?: {
+    verifiedStatus?: string;
+    trustedVerifierStatus?: string;
+    verifications?: { issuer?: string; isValid?: boolean }[];
+  };
 };
 
 declare type BlueskyReply = {
@@ -191,6 +196,7 @@ declare type BlueskyProfileViewDetailed = {
   verification?: {
     verifiedStatus?: string;
     trustedVerifierStatus?: string;
+    verifications?: { issuer?: string; isValid?: boolean; uri?: string; createdAt?: string }[];
   };
 };
 
@@ -207,6 +213,7 @@ declare type BlueskyProfileView = {
   verification?: {
     verifiedStatus?: string;
     trustedVerifierStatus?: string;
+    verifications?: { issuer?: string; isValid?: boolean; uri?: string; createdAt?: string }[];
   };
 };
 

--- a/test/bluesky.api.test.ts
+++ b/test/bluesky.api.test.ts
@@ -43,12 +43,20 @@ test('GET /2/status uses rkey as id and returns cid', async () => {
   expect(res.status).toBe(200);
   const body = (await res.json()) as {
     code: number;
-    status: { id: string; cid?: string; url: string; quote?: { text: string } };
+    status: {
+      id: string;
+      cid?: string;
+      url: string;
+      quote?: { text: string };
+      author?: { verification?: { verified?: boolean; verified_by?: string } };
+    };
   };
   expect(body.code).toBe(200);
   expect(body.status.id).toBe('rkeymain');
   expect(body.status.cid).toBe('bafycidmain');
   expect(body.status.url).toContain('/author.test/post/rkeymain');
+  expect(body.status.author?.verification?.verified).toBe(true);
+  expect(body.status.author?.verification?.verified_by).toBe('bsky.app');
 });
 
 // test('GET /2/status quote notFound yields tombstone quote', async () => {
@@ -285,6 +293,7 @@ test('GET /2/profile returns user envelope and counts', async () => {
       following: number;
       statuses: number;
       id: string;
+      verification?: { verified?: boolean; verified_by?: string };
     };
   };
   expect(body.code).toBe(200);
@@ -295,6 +304,8 @@ test('GET /2/profile returns user envelope and counts', async () => {
   expect(body.user?.following).toBe(50);
   expect(body.user?.statuses).toBe(42);
   expect(body.user?.description).toContain('https://example.com/page');
+  expect(body.user?.verification?.verified).toBe(true);
+  expect(body.user?.verification?.verified_by).toBe('bsky.app');
 });
 
 test('GET /2/profile/{handle}/statuses returns feed, cursor.bottom, and reposted_by', async () => {

--- a/test/bluesky.verification-map.test.ts
+++ b/test/bluesky.verification-map.test.ts
@@ -1,0 +1,54 @@
+import { expect, test } from 'vitest';
+import {
+  BLUESKY_APP_OFFICIAL_ISSUER_DID,
+  blueskyVerificationToApiUserVerification
+} from '../src/providers/bluesky/verification';
+
+test('blueskyVerificationToApiUserVerification returns undefined when not valid', () => {
+  expect(blueskyVerificationToApiUserVerification(undefined)).toBeUndefined();
+  expect(
+    blueskyVerificationToApiUserVerification({ verifiedStatus: 'none', verifications: [] })
+  ).toBeUndefined();
+});
+
+test('blueskyVerificationToApiUserVerification maps official Bluesky issuer to bsky.app', () => {
+  expect(
+    blueskyVerificationToApiUserVerification({
+      verifiedStatus: 'valid',
+      verifications: [
+        { issuer: 'did:plc:other', isValid: true },
+        { issuer: BLUESKY_APP_OFFICIAL_ISSUER_DID, isValid: true }
+      ]
+    })
+  ).toEqual({
+    verified: true,
+    type: null,
+    verified_at: null,
+    verified_by: 'bsky.app'
+  });
+});
+
+test('blueskyVerificationToApiUserVerification uses first valid non-official issuer DID', () => {
+  expect(
+    blueskyVerificationToApiUserVerification({
+      verifiedStatus: 'valid',
+      verifications: [{ issuer: 'did:plc:nytimesfixture', isValid: true }]
+    })
+  ).toEqual({
+    verified: true,
+    type: null,
+    verified_at: null,
+    verified_by: 'did:plc:nytimesfixture'
+  });
+});
+
+test('blueskyVerificationToApiUserVerification falls back to trusted_verifier when verifications missing', () => {
+  expect(
+    blueskyVerificationToApiUserVerification({ verifiedStatus: 'valid', verifications: [] })
+  ).toEqual({
+    verified: true,
+    type: null,
+    verified_at: null,
+    verified_by: 'trusted_verifier'
+  });
+});

--- a/test/fixtures/bluesky/profile-detail.json
+++ b/test/fixtures/bluesky/profile-detail.json
@@ -9,5 +9,17 @@
   "followsCount": 50,
   "postsCount": 42,
   "indexedAt": "2024-06-01T12:00:00.000Z",
-  "labels": []
+  "labels": [],
+  "verification": {
+    "verifiedStatus": "valid",
+    "trustedVerifierStatus": "none",
+    "verifications": [
+      {
+        "issuer": "did:plc:z72i7hdynmk6r22z27h6tvur",
+        "uri": "at://did:plc:z72i7hdynmk6r22z27h6tvur/app.bsky.graph.verification/vfixture",
+        "isValid": true,
+        "createdAt": "2024-06-01T00:00:00.000Z"
+      }
+    ]
+  }
 }

--- a/test/fixtures/bluesky/thread-single.json
+++ b/test/fixtures/bluesky/thread-single.json
@@ -11,7 +11,19 @@
         "avatar": "https://cdn.bsky.app/img/avatar.png",
         "createdAt": "2023-01-01T00:00:00.000Z",
         "associated": { "chat": { "allowIncoming": "all" } },
-        "labels": []
+        "labels": [],
+        "verification": {
+          "verifiedStatus": "valid",
+          "trustedVerifierStatus": "none",
+          "verifications": [
+            {
+              "issuer": "did:plc:z72i7hdynmk6r22z27h6tvur",
+              "uri": "at://did:plc:z72i7hdynmk6r22z27h6tvur/app.bsky.graph.verification/vfixture",
+              "isValid": true,
+              "createdAt": "2024-06-01T00:00:00.000Z"
+            }
+          ]
+        }
       },
       "record": {
         "$type": "app.bsky.feed.post",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Bluesky’s ATProto `verificationState` does not map cleanly to Twitter-style `verification.type`. This change extends the shared `APIUser.verification` object with an optional `verified_by` string and fills it for Bluesky sources.

## Behavior

- When `verifiedStatus` is `valid`:
  - If any valid verification lists the official Bluesky issuer DID (`did:plc:z72i7hdynmk6r22z27h6tvur`, the `bsky.app` PLC identity), `verified_by` is **`bsky.app`**.
  - Otherwise, if there is at least one valid verification with an `issuer` DID, `verified_by` is that **issuer DID** (first match in upstream order).
  - If the account is marked valid but `verifications` is empty or has no valid issuers, `verified_by` is **`trusted_verifier`** so clients still get a non-empty signal.

## Code

- New helper: `src/providers/bluesky/verification.ts`
- Wired from `blueskyProfileToApiUser`, `blueskyProfileViewToApiUser`, and `apiUserFromAuthor` in the Bluesky processor (post/thread authors).

## Tests

- Unit tests for the mapper
- FxBluesky API fixtures extended so profile and status responses assert `verification.verified_by === 'bsky.app'`

## Note

FxTwitter responses are unchanged except that the OpenAPI schema now documents the optional `verified_by` field on `APIUser.verification` (always omitted for non-Bluesky providers).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d0a4530e-5e6d-4971-af1e-d5357399db92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d0a4530e-5e6d-4971-af1e-d5357399db92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for displaying user verification information from Bluesky accounts, showing verification status and which service authenticated each user.

* **Refactor**
  * Consolidated verification conversion and mapping logic into a dedicated module for use across all Bluesky profile types and endpoints.

* **Tests**
  * Added comprehensive test coverage for verification mapping behavior including official and third-party verifier scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->