### PR TITLE
Handle SearchTimeline empty and blocklisted query errors

### DIFF
--- a/packages/atmosphere/src/providers/twitter/proxy/errors.ts
+++ b/packages/atmosphere/src/providers/twitter/proxy/errors.ts
@@ -1,4 +1,8 @@
 /* Twitter API error payloads are loosely typed */
+import {
+  isSearchTimelineClientErrorResponse,
+  parseSearchTimelineClientError
+} from '../searchErrors.js';
 import type { ErrorResponse } from '../../../types/proxy-credentials.js';
 
 const JSON_HEADERS = { 'Content-Type': 'application/json' } as const;
@@ -188,8 +192,20 @@ const ERROR_RULES: ErrorRule[] = [
     ),
     disposition: 'ignore',
     log: 'Downstream fetch problem (Internal server error); retrying with another account.'
+  },
+  {
+    match: ({ json }) => parseSearchTimelineClientError(json) === 'empty_query',
+    disposition: 'ignore',
+    log: 'SearchTimeline empty or unparseable query (expected client error)'
+  },
+  {
+    match: ({ json }) => parseSearchTimelineClientError(json) === 'blocklisted',
+    disposition: 'ignore',
+    log: 'SearchTimeline blocklisted query (expected client error)'
   }
 ];
+
+export { isSearchTimelineClientErrorResponse };
 
 export function applyNsfwViewerErrorPatch(json: unknown): void {
   const rec = asRecord(json);

--- a/packages/atmosphere/src/providers/twitter/proxy/handler.ts
+++ b/packages/atmosphere/src/providers/twitter/proxy/handler.ts
@@ -5,6 +5,7 @@ import { mergeCookies } from './cookies.js';
 import { needsTransactionId } from './allowlist.js';
 import {
   classifyAPIErrors,
+  isSearchTimelineClientErrorResponse,
   jsonError,
   jsonHasTruthyErrorsProperty,
   twitterResponseLooksEmpty
@@ -168,7 +169,7 @@ export async function proxyTwitterRequest(request: Request, env: ProxyEnv): Prom
           }
         }
 
-        if (twitterResponseLooksEmpty(json)) {
+        if (twitterResponseLooksEmpty(json) && !isSearchTimelineClientErrorResponse(json)) {
           console.log(
             `No data was sent. Response code ${response.status}. Data sent`,
             rawBody ?? '[empty]'

--- a/packages/atmosphere/src/providers/twitter/search.ts
+++ b/packages/atmosphere/src/providers/twitter/search.ts
@@ -3,7 +3,12 @@ import { buildAPITwitterStatus } from './processor.js';
 import { SearchTimelineQuery } from './graphql/queries.js';
 import { graphqlRequest } from './graphql/request.js';
 import { isTombstone } from '../../helpers/tombstone.js';
-import type { APISearchResults, APITwitterStatus } from '../../types/api-schemas.js';
+import {
+  isSearchTimelineClientErrorResponse,
+  parseSearchTimelineClientError,
+  searchTimelineClientErrorToApiQueryError
+} from './searchErrors.js';
+import type { APISearchResults, APITwitterStatus, ApiQueryError } from '../../types/api-schemas.js';
 import type { FetchResults } from '../../types/fetch-results.js';
 import type { TwitterBuildHost } from './build-host.js';
 
@@ -433,7 +438,7 @@ export const searchAPI = async (
   cursor: string | null,
   host: TwitterBuildHost,
   language?: string
-): Promise<APISearchResults> => {
+): Promise<APISearchResults | ApiQueryError> => {
   const product = feedToProduct(feed);
 
   let response: TwitterSearchTimelineResponse | null;
@@ -449,6 +454,9 @@ export const searchAPI = async (
       },
       headers: buildLanguageHeaders(language),
       validator: (_response: unknown) => {
+        if (isSearchTimelineClientErrorResponse(_response)) {
+          return true;
+        }
         const r = _response as TwitterSearchTimelineResponse;
         return Array.isArray(r?.data?.search_by_raw_query?.search_timeline?.timeline?.instructions);
       }
@@ -456,6 +464,11 @@ export const searchAPI = async (
   } catch (e) {
     console.error('Search request failed', e);
     return { code: 500, results: [], cursor: { top: null, bottom: null } };
+  }
+
+  const clientError = parseSearchTimelineClientError(response);
+  if (clientError) {
+    return searchTimelineClientErrorToApiQueryError(clientError);
   }
 
   if (!response?.data?.search_by_raw_query?.search_timeline?.timeline?.instructions) {

--- a/packages/atmosphere/src/providers/twitter/searchErrors.ts
+++ b/packages/atmosphere/src/providers/twitter/searchErrors.ts
@@ -19,9 +19,7 @@ function firstGraphqlErrorEntry(json: unknown): Record<string, unknown> | undefi
 
 function isSearchTimelineErrorPath(path: unknown): boolean {
   if (!Array.isArray(path) || path.length === 0) return true;
-  return path.some(
-    segment => segment === 'search_timeline' || segment === 'search_by_raw_query'
-  );
+  return path.some(segment => segment === 'search_timeline' || segment === 'search_by_raw_query');
 }
 
 /**

--- a/packages/atmosphere/src/providers/twitter/searchErrors.ts
+++ b/packages/atmosphere/src/providers/twitter/searchErrors.ts
@@ -17,6 +17,14 @@ function firstGraphqlErrorEntry(json: unknown): Record<string, unknown> | undefi
   return asRecord(errors[0]);
 }
 
+/**
+ * Validate if an error path relates to search timeline operations.
+ *
+ * Note: Returns `true` when path is missing, null, or empty. This permissive behavior
+ * is intentional and allows errors without path information to proceed to message-based
+ * classification. This defensive design handles API response variations where the path
+ * field may be omitted while still containing valid search timeline error messages.
+ */
 function isSearchTimelineErrorPath(path: unknown): boolean {
   if (!Array.isArray(path) || path.length === 0) return true;
   return path.some(segment => segment === 'search_timeline' || segment === 'search_by_raw_query');

--- a/packages/atmosphere/src/providers/twitter/searchErrors.ts
+++ b/packages/atmosphere/src/providers/twitter/searchErrors.ts
@@ -1,0 +1,68 @@
+import type { ApiQueryError } from '../../types/api-schemas.js';
+
+export type SearchTimelineClientErrorKind = 'empty_query' | 'blocklisted';
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  if (value !== null && typeof value === 'object') {
+    return value as Record<string, unknown>;
+  }
+  return undefined;
+}
+
+function firstGraphqlErrorEntry(json: unknown): Record<string, unknown> | undefined {
+  const rec = asRecord(json);
+  if (!rec) return undefined;
+  const errors = rec['errors'];
+  if (!Array.isArray(errors) || errors.length === 0) return undefined;
+  return asRecord(errors[0]);
+}
+
+function isSearchTimelineErrorPath(path: unknown): boolean {
+  if (!Array.isArray(path) || path.length === 0) return true;
+  return path.some(
+    segment => segment === 'search_timeline' || segment === 'search_by_raw_query'
+  );
+}
+
+/**
+ * Detect expected SearchTimeline client validation errors from X GraphQL (`errors[0].message`).
+ */
+export function parseSearchTimelineClientError(
+  json: unknown
+): SearchTimelineClientErrorKind | null {
+  const entry = firstGraphqlErrorEntry(json);
+  if (!entry) return null;
+
+  const message = entry['message'];
+  if (typeof message !== 'string') return null;
+  if (!isSearchTimelineErrorPath(entry['path'])) return null;
+
+  if (message.includes('ERROR_EMPTY_QUERY')) {
+    return 'empty_query';
+  }
+  if (message.includes('denylisted in Search Content Control tool')) {
+    return 'blocklisted';
+  }
+  return null;
+}
+
+export function isSearchTimelineClientErrorResponse(json: unknown): boolean {
+  return parseSearchTimelineClientError(json) !== null;
+}
+
+export function searchTimelineClientErrorToApiQueryError(
+  kind: SearchTimelineClientErrorKind
+): ApiQueryError {
+  switch (kind) {
+    case 'empty_query':
+      return {
+        code: 400,
+        message: 'Search query is empty or could not be parsed by X'
+      };
+    case 'blocklisted':
+      return {
+        code: 400,
+        message: 'Search query is blocked by X content controls'
+      };
+  }
+}

--- a/packages/atmosphere/src/providers/twitter/statusQuotes.ts
+++ b/packages/atmosphere/src/providers/twitter/statusQuotes.ts
@@ -1,5 +1,5 @@
 import { searchAPI } from './search.js';
-import type { APISearchResults } from '../../types/api-schemas.js';
+import type { APISearchResults, ApiQueryError } from '../../types/api-schemas.js';
 import type { TwitterBuildHost } from './build-host.js';
 
 export const statusQuotesAPI = async (
@@ -8,6 +8,6 @@ export const statusQuotesAPI = async (
   cursor: string | null,
   host: TwitterBuildHost,
   language?: string
-): Promise<APISearchResults> => {
+): Promise<APISearchResults | ApiQueryError> => {
   return searchAPI(`quoted_tweet_id:${statusId}`, 'latest', count, cursor, host, language);
 };

--- a/test/api.search.test.ts
+++ b/test/api.search.test.ts
@@ -102,3 +102,33 @@ test('API search accepts count parameter', async () => {
   const response = (await result.json()) as APISearchResults;
   expect(response.code).toEqual(200);
 });
+
+test('API search returns 400 for upstream empty query error', async () => {
+  const result = await app.request(
+    new Request('https://api.fxtwitter.com/2/search?q=empty_query_error', {
+      method: 'GET',
+      headers: botHeaders
+    }),
+    undefined,
+    harness
+  );
+  expect(result.status).toEqual(400);
+  const body = (await result.json()) as { code?: number; message?: string };
+  expect(body.code).toEqual(400);
+  expect(body.message).toContain('empty or could not be parsed');
+});
+
+test('API search returns 400 for upstream blocklisted query error', async () => {
+  const result = await app.request(
+    new Request('https://api.fxtwitter.com/2/search?q=blocklisted_query', {
+      method: 'GET',
+      headers: botHeaders
+    }),
+    undefined,
+    harness
+  );
+  expect(result.status).toEqual(400);
+  const body = (await result.json()) as { code?: number; message?: string };
+  expect(body.code).toEqual(400);
+  expect(body.message).toContain('blocked by X content controls');
+});

--- a/test/mocks/SearchTimeline/blocklisted_query.json
+++ b/test/mocks/SearchTimeline/blocklisted_query.json
@@ -1,0 +1,21 @@
+{
+  "errors": [
+    {
+      "message": "BadRequest: Query is denylisted in Search Content Control tool.",
+      "locations": [{ "line": 3, "column": 5 }],
+      "path": ["search_by_raw_query", "search_timeline", "timeline"],
+      "extensions": {
+        "name": "BadRequestError",
+        "source": "Client",
+        "code": 214,
+        "kind": "Validation",
+        "tracing": { "trace_id": "00000000000000000000000000000000" }
+      },
+      "code": 214,
+      "kind": "Validation",
+      "name": "BadRequestError",
+      "source": "Client"
+    }
+  ],
+  "data": {}
+}

--- a/test/mocks/SearchTimeline/empty_query_error.json
+++ b/test/mocks/SearchTimeline/empty_query_error.json
@@ -1,0 +1,21 @@
+{
+  "errors": [
+    {
+      "message": "BadRequest: SearchQueryParsingException(ERROR_EMPTY_QUERY)",
+      "locations": [{ "line": 3, "column": 5 }],
+      "path": ["search_by_raw_query", "search_timeline", "timeline"],
+      "extensions": {
+        "name": "BadRequestError",
+        "source": "Client",
+        "code": 214,
+        "kind": "Validation",
+        "tracing": { "trace_id": "00000000000000000000000000000000" }
+      },
+      "code": 214,
+      "kind": "Validation",
+      "name": "BadRequestError",
+      "source": "Client"
+    }
+  ],
+  "data": {}
+}

--- a/test/searchTimelineErrors.test.ts
+++ b/test/searchTimelineErrors.test.ts
@@ -45,6 +45,19 @@ test('parseSearchTimelineClientError ignores unrelated GraphQL errors', () => {
   expect(parseSearchTimelineClientError({ data: {} })).toBeNull();
 });
 
+test('parseSearchTimelineClientError accepts known messages without path', () => {
+  expect(
+    parseSearchTimelineClientError({
+      errors: [{ message: 'BadRequest: SearchQueryParsingException(ERROR_EMPTY_QUERY)' }]
+    })
+  ).toBe('empty_query');
+  expect(
+    parseSearchTimelineClientError({
+      errors: [{ message: 'BadRequest: Query is denylisted in Search Content Control tool.' }]
+    })
+  ).toBe('blocklisted');
+});
+
 test('searchTimelineClientErrorToApiQueryError maps to API 400 messages', () => {
   expect(searchTimelineClientErrorToApiQueryError('empty_query')).toEqual({
     code: 400,

--- a/test/searchTimelineErrors.test.ts
+++ b/test/searchTimelineErrors.test.ts
@@ -1,0 +1,57 @@
+import { test, expect } from 'vitest';
+import {
+  isSearchTimelineClientErrorResponse,
+  parseSearchTimelineClientError,
+  searchTimelineClientErrorToApiQueryError
+} from '@fxembed/atmosphere/providers/twitter/searchErrors';
+
+const emptyQueryError = {
+  errors: [
+    {
+      message: 'BadRequest: SearchQueryParsingException(ERROR_EMPTY_QUERY)',
+      path: ['search_by_raw_query', 'search_timeline', 'timeline'],
+      code: 214
+    }
+  ],
+  data: {}
+};
+
+const blocklistedError = {
+  errors: [
+    {
+      message: 'BadRequest: Query is denylisted in Search Content Control tool.',
+      path: ['search_by_raw_query', 'search_timeline', 'timeline'],
+      code: 214
+    }
+  ],
+  data: {}
+};
+
+test('parseSearchTimelineClientError detects empty query', () => {
+  expect(parseSearchTimelineClientError(emptyQueryError)).toBe('empty_query');
+  expect(isSearchTimelineClientErrorResponse(emptyQueryError)).toBe(true);
+});
+
+test('parseSearchTimelineClientError detects blocklisted query', () => {
+  expect(parseSearchTimelineClientError(blocklistedError)).toBe('blocklisted');
+});
+
+test('parseSearchTimelineClientError ignores unrelated GraphQL errors', () => {
+  expect(
+    parseSearchTimelineClientError({
+      errors: [{ message: 'BadRequest: SearchQueryParsingException(ERROR_EMPTY_QUERY)', path: ['user'] }]
+    })
+  ).toBeNull();
+  expect(parseSearchTimelineClientError({ data: {} })).toBeNull();
+});
+
+test('searchTimelineClientErrorToApiQueryError maps to API 400 messages', () => {
+  expect(searchTimelineClientErrorToApiQueryError('empty_query')).toEqual({
+    code: 400,
+    message: 'Search query is empty or could not be parsed by X'
+  });
+  expect(searchTimelineClientErrorToApiQueryError('blocklisted')).toEqual({
+    code: 400,
+    message: 'Search query is blocked by X content controls'
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds dedicated handling for two expected X `SearchTimeline` GraphQL client validation errors that were previously treated as upstream failures (triggering Discord exception alerts and returning 404/500 to API clients).

- **Empty/unparseable query** — `SearchQueryParsingException(ERROR_EMPTY_QUERY)`
- **Blocklisted query** — `Query is denylisted in Search Content Control tool.`

Both now return **HTTP 400** with clear `ApiQueryError` messages from `GET /2/search`.

## Changes

- New `searchErrors.ts` helper to detect SearchTimeline-specific GraphQL errors by message + path
- `searchAPI` accepts these error payloads as valid responses (no guest-token retries) and maps them to 400
- Account proxy treats these as expected client errors: no Discord alerts, no credential rotation retries
- Documented fail-open path matching when X omits `errors[0].path`
- Added unit test coverage for missing-path error payloads

## Testing

- Unit tests for error parsing/mapping (`test/searchTimelineErrors.test.ts`)
- Integration tests for `/2/search` with mocked upstream error payloads (`test/api.search.test.ts`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b5f67241-bd74-43f5-9833-fe53a870e8ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b5f67241-bd74-43f5-9833-fe53a870e8ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search API now returns structured, descriptive 400 errors for empty queries and searches blocked by content controls.
* **Bug Fixes**
  * Prevented client-side search validation errors from being treated as empty failures, reducing unnecessary retries and account switching.
* **Tests**
  * Added fixtures and automated coverage for empty-query and blocked-search error parsing and the resulting API HTTP responses/messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->