### PR TITLE
fix: exclude X pseudo language codes from translation

### DIFF
--- a/packages/atmosphere/src/helpers/language.ts
+++ b/packages/atmosphere/src/helpers/language.ts
@@ -12,6 +12,28 @@ export const buildLanguageHeaders = (
   return { 'x-twitter-client-language': normalizeLanguage(cleaned) };
 };
 
+/**
+ * ISO / X pseudo language codes that do not represent a real source language.
+ * @see https://devcommunity.x.com/t/unkown-language-code-qht-returned-by-api/172819/3
+ */
+export const NON_TRANSLATABLE_LANGUAGE_CODES = new Set([
+  'unk',
+  'und',
+  'zxx',
+  'qam', // mentions only
+  'qct', // cashtags only
+  'qht', // hashtags only
+  'qme', // media links
+  'qst' // very short text
+]);
+
+export const isTranslatableLanguageCode = (language: string | null | undefined): boolean => {
+  if (typeof language !== 'string' || language.length === 0) {
+    return false;
+  }
+  return !NON_TRANSLATABLE_LANGUAGE_CODES.has(language.toLowerCase());
+};
+
 export const normalizeLanguage = (language: string) => {
   switch (language) {
     case 'zh':

--- a/packages/atmosphere/src/helpers/language.ts
+++ b/packages/atmosphere/src/helpers/language.ts
@@ -28,10 +28,14 @@ export const NON_TRANSLATABLE_LANGUAGE_CODES = new Set([
 ]);
 
 export const isTranslatableLanguageCode = (language: string | null | undefined): boolean => {
-  if (typeof language !== 'string' || language.length === 0) {
+  if (typeof language !== 'string') {
     return false;
   }
-  return !NON_TRANSLATABLE_LANGUAGE_CODES.has(language.toLowerCase());
+  const trimmed = language.trim();
+  if (trimmed.length === 0) {
+    return false;
+  }
+  return !NON_TRANSLATABLE_LANGUAGE_CODES.has(trimmed.toLowerCase());
 };
 
 export const normalizeLanguage = (language: string) => {

--- a/packages/atmosphere/src/providers/twitter/processor.ts
+++ b/packages/atmosphere/src/providers/twitter/processor.ts
@@ -19,7 +19,7 @@ import type {
 import type { FetchResults } from '../../types/fetch-results.js';
 import { isTombstone, tombstoneMessageForReason } from '../../helpers/tombstone.js';
 import { translateStatusGrok } from '../../helpers/translate-grok.js';
-import { normalizeLanguage } from '../../helpers/language.js';
+import { normalizeLanguage, isTranslatableLanguageCode } from '../../helpers/language.js';
 import { tcoResolver } from './tcoResolver.js';
 import type { TwitterBuildHost } from './build-host.js';
 
@@ -640,11 +640,7 @@ export const buildAPITwitterStatus = async (
     apiStatus.community_note = null;
   }
 
-  if (
-    status.legacy.lang !== 'unk' &&
-    status.legacy.lang !== 'und' &&
-    status.legacy.lang !== 'zxx'
-  ) {
+  if (isTranslatableLanguageCode(status.legacy.lang)) {
     apiStatus.lang = status.legacy.lang;
   } else {
     apiStatus.lang = null;
@@ -988,6 +984,7 @@ export const buildAPITwitterStatus = async (
   if (
     typeof language === 'string' &&
     (language.length === 2 || language.length === 5) && // Only translate if the language is a valid ISO 639-1 or ISO 639-5 code
+    isTranslatableLanguageCode(status.legacy?.lang) &&
     normalizeLanguage(language) !== normalizeLanguage(status.legacy?.lang || '') &&
     apiStatus.text.length > 1 // Don't translate if the status text is too short
   ) {

--- a/src/helpers/language.ts
+++ b/src/helpers/language.ts
@@ -1,1 +1,5 @@
-export { buildLanguageHeaders, normalizeLanguage } from '@fxembed/atmosphere/helpers';
+export {
+  buildLanguageHeaders,
+  isTranslatableLanguageCode,
+  normalizeLanguage
+} from '@fxembed/atmosphere/helpers';

--- a/test/language.test.ts
+++ b/test/language.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from 'vitest';
+import {
+  isTranslatableLanguageCode,
+  NON_TRANSLATABLE_LANGUAGE_CODES
+} from '@fxembed/atmosphere/helpers';
+
+test('NON_TRANSLATABLE_LANGUAGE_CODES includes X pseudo language codes', () => {
+  expect(NON_TRANSLATABLE_LANGUAGE_CODES.has('qht')).toBe(true);
+  expect(NON_TRANSLATABLE_LANGUAGE_CODES.has('qam')).toBe(true);
+  expect(NON_TRANSLATABLE_LANGUAGE_CODES.has('qct')).toBe(true);
+  expect(NON_TRANSLATABLE_LANGUAGE_CODES.has('qme')).toBe(true);
+  expect(NON_TRANSLATABLE_LANGUAGE_CODES.has('qst')).toBe(true);
+  expect(NON_TRANSLATABLE_LANGUAGE_CODES.has('zxx')).toBe(true);
+  expect(NON_TRANSLATABLE_LANGUAGE_CODES.has('unk')).toBe(true);
+  expect(NON_TRANSLATABLE_LANGUAGE_CODES.has('und')).toBe(true);
+});
+
+test('isTranslatableLanguageCode accepts real language codes', () => {
+  expect(isTranslatableLanguageCode('en')).toBe(true);
+  expect(isTranslatableLanguageCode('ja')).toBe(true);
+  expect(isTranslatableLanguageCode('zh-cn')).toBe(true);
+});
+
+test('isTranslatableLanguageCode rejects pseudo and unknown language codes', () => {
+  for (const code of NON_TRANSLATABLE_LANGUAGE_CODES) {
+    expect(isTranslatableLanguageCode(code)).toBe(false);
+    expect(isTranslatableLanguageCode(code.toUpperCase())).toBe(false);
+  }
+
+  expect(isTranslatableLanguageCode('')).toBe(false);
+  expect(isTranslatableLanguageCode(null)).toBe(false);
+  expect(isTranslatableLanguageCode(undefined)).toBe(false);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #2151

## Summary

Twitter/X returns pseudo ISO language codes for tweets without detectable language content (e.g. hashtags-only, mentions-only, media-only). These codes were being treated as real languages, causing unwanted translation attempts and broken "Translated from …" labels.

## Changes

- Add `isTranslatableLanguageCode()` and `NON_TRANSLATABLE_LANGUAGE_CODES` in `@fxembed/atmosphere` for the known non-language codes: `unk`, `und`, `zxx`, `qam`, `qct`, `qht`, `qme`, `qst`.
- Use the helper when setting `apiStatus.lang` (extends the existing `zxx` handling).
- Skip Grok/Polyglot/AI translation when the tweet's source language is not translatable.
- Add unit tests for the new helper.

## Test plan

- [x] `npm run test -- test/language.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-628ef9b7-a1e4-4445-9413-90487f56b15b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-628ef9b7-a1e4-4445-9413-90487f56b15b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a language code validation utility and a list of non-translatable codes to consistently exclude unsupported values from translation processing.
  * Enabled case-insensitive language-code checks to improve reliability of translation decisions.

* **Bug Fixes**
  * Updated Twitter language handling to rely on the shared validation utility, preventing unintended translation attempts for non-translatable codes.

* **Tests**
  * Added Vitest coverage for non-translatable code detection and correct translatable/non-translatable behavior (including empty and null inputs).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->