### PR TITLE
Support Bluesky gallery embeds for image carousels

### DIFF
--- a/packages/atmosphere/src/providers/bluesky/gallery.ts
+++ b/packages/atmosphere/src/providers/bluesky/gallery.ts
@@ -1,0 +1,62 @@
+import type { APIPhoto } from '../../types/api-schemas.js';
+
+/** Hydrated `app.bsky.embed.gallery#viewImage` from AppView. */
+export type BlueskyGalleryViewImage = {
+  $type?: string;
+  thumbnail?: string;
+  fullsize?: string;
+  alt?: string;
+  aspectRatio?: {
+    width: number;
+    height: number;
+  };
+};
+
+export const isBlueskyGalleryEmbed = (embed: BlueskyEmbed | undefined): boolean => {
+  if (!embed || typeof embed !== 'object') return false;
+  if (embed.$type?.includes('gallery')) return true;
+  return Array.isArray(embed.items) && embed.items.length > 0;
+};
+
+export const blueskyGalleryItemsToPhotos = (
+  items: BlueskyGalleryViewImage[] | undefined
+): APIPhoto[] => {
+  if (!Array.isArray(items) || items.length === 0) return [];
+
+  const photos: APIPhoto[] = [];
+  for (const item of items) {
+    if (!item || typeof item !== 'object') continue;
+    const url = item.fullsize ?? item.thumbnail;
+    if (!url) continue;
+    photos.push({
+      type: 'photo',
+      width: item.aspectRatio?.width ?? 0,
+      height: item.aspectRatio?.height ?? 0,
+      url,
+      altText: item.alt
+    });
+  }
+  return photos;
+};
+
+export const blueskyPhotosFromEmbed = (embed: BlueskyEmbed | undefined): APIPhoto[] => {
+  if (!embed) return [];
+
+  if (isBlueskyGalleryEmbed(embed)) {
+    return blueskyGalleryItemsToPhotos(embed.items as BlueskyGalleryViewImage[]);
+  }
+
+  const images =
+    embed.images ??
+    embed.media?.images;
+
+  if (!Array.isArray(images) || images.length === 0) return [];
+
+  return images.map(image => ({
+    type: 'photo' as const,
+    width: image.aspectRatio?.width ?? 0,
+    height: image.aspectRatio?.height ?? 0,
+    url: image.fullsize,
+    altText: image.alt
+  }));
+};

--- a/packages/atmosphere/src/providers/bluesky/gallery.ts
+++ b/packages/atmosphere/src/providers/bluesky/gallery.ts
@@ -1,17 +1,5 @@
 import type { APIPhoto } from '../../types/api-schemas.js';
 
-/** Hydrated `app.bsky.embed.gallery#viewImage` from AppView. */
-export type BlueskyGalleryViewImage = {
-  $type?: string;
-  thumbnail?: string;
-  fullsize?: string;
-  alt?: string;
-  aspectRatio?: {
-    width: number;
-    height: number;
-  };
-};
-
 export const isBlueskyGalleryEmbed = (embed: BlueskyEmbed | undefined): boolean => {
   if (!embed || typeof embed !== 'object') return false;
   if (embed.$type?.includes('gallery')) return true;
@@ -43,7 +31,7 @@ export const blueskyPhotosFromEmbed = (embed: BlueskyEmbed | undefined): APIPhot
   if (!embed) return [];
 
   if (isBlueskyGalleryEmbed(embed)) {
-    return blueskyGalleryItemsToPhotos(embed.items as BlueskyGalleryViewImage[]);
+    return blueskyGalleryItemsToPhotos(embed.items);
   }
 
   const images =

--- a/packages/atmosphere/src/providers/bluesky/processor.ts
+++ b/packages/atmosphere/src/providers/bluesky/processor.ts
@@ -10,6 +10,7 @@ import type { APIStatusTombstone, APITombstoneReason, APIUser } from '../../type
 import type { APIStatus } from '../../types/api-status.js';
 import { isTombstone, tombstoneMessageForReason } from '../../helpers/tombstone.js';
 import { blueskyVerificationToApiUserVerification } from './verification.js';
+import { blueskyPhotosFromEmbed } from './gallery.js';
 import type { BlueskyBuildHost } from './build-host.js';
 
 export const buildBlueskyTombstone = (
@@ -210,16 +211,13 @@ const applyEmbedsToStatus = async (apiStatus: APIStatus, status: BlueskyPost): P
   const media = primary?.media ?? status.embeds?.[0]?.media;
   const authorDid = status.author?.did;
 
-  if (primary?.media?.images?.length || status.embeds?.[0]?.images?.length) {
+  let embedPhotos = blueskyPhotosFromEmbed(primary);
+  if (!embedPhotos.length && status.embeds?.[0] && status.embeds[0] !== primary) {
+    embedPhotos = blueskyPhotosFromEmbed(status.embeds[0]);
+  }
+  if (embedPhotos.length) {
     apiStatus.embed_card = 'summary_large_image';
-    const images = primary?.media?.images ?? (status.embeds?.[0]?.images as BlueskyImage[]);
-    apiStatus.media.photos = images.map(image => ({
-      type: 'photo' as const,
-      width: image.aspectRatio?.width,
-      height: image.aspectRatio?.height,
-      url: image.fullsize,
-      altText: image.alt
-    }));
+    apiStatus.media.photos = embedPhotos;
   }
 
   if (status.embeds?.[0]?.video || primary?.video) {
@@ -269,19 +267,7 @@ const applyEmbedsToStatus = async (apiStatus: APIStatus, status: BlueskyPost): P
     }
   }
 
-  if (primary?.images?.length) {
-    apiStatus.embed_card = 'summary_large_image';
-    apiStatus.media.photos = primary.images.map(image => ({
-      type: 'photo' as const,
-      width: image.aspectRatio?.width,
-      height: image.aspectRatio?.height,
-      url: image.fullsize,
-      altText: image.alt
-    }));
-  }
-
-  if (
-    status.record?.embed?.video ||
+  if (status.record?.embed?.video ||
     status.value?.embed?.video ||
     primary?.media?.$type === 'app.bsky.embed.video#view'
   ) {

--- a/packages/atmosphere/src/providers/bluesky/search.ts
+++ b/packages/atmosphere/src/providers/bluesky/search.ts
@@ -1,6 +1,7 @@
 import type { APIBlueskyStatus, APISearchResultsBluesky } from '../../types/api-schemas.js';
 import { buildAPIBlueskyPost } from './processor.js';
 import { fetchSearchPosts } from './client.js';
+import { isBlueskyGalleryEmbed } from './gallery.js';
 import type { BlueskyBuildHost } from './build-host.js';
 
 export type BlueskySearchFeed = 'latest' | 'top' | 'media';
@@ -17,6 +18,7 @@ function normalizePostView(post: BlueskyPost): BlueskyPost {
 
 function embedHasVisualMedia(embed: BlueskyEmbed | undefined): boolean {
   if (!embed || typeof embed !== 'object') return false;
+  if (isBlueskyGalleryEmbed(embed)) return true;
   if (Array.isArray(embed.images) && embed.images.length > 0) return true;
   if (embed.video || embed.$type?.includes('video')) return true;
   if (embed.external) return true;

--- a/packages/atmosphere/src/raw/vendor/bluesky.d.ts
+++ b/packages/atmosphere/src/raw/vendor/bluesky.d.ts
@@ -77,9 +77,23 @@ declare type BlueskyEmbedViewRecord = {
   indexedAt?: string;
 };
 
+/** Hydrated `app.bsky.embed.gallery#viewImage` from AppView. */
+declare type BlueskyGalleryViewImage = {
+  $type?: string;
+  thumbnail?: string;
+  fullsize?: string;
+  alt?: string;
+  aspectRatio?: {
+    height: number;
+    width: number;
+  };
+};
+
 declare type BlueskyEmbed = {
   $type?: string;
   images?: BlueskyImage[];
+  /** `app.bsky.embed.gallery#view` items (carousel / multi-image posts with 5+ images). */
+  items?: BlueskyGalleryViewImage[];
   video?: BlueskyVideo;
   media?: BlueskyMedia;
   external?: BlueskyExternalEmbed;

--- a/test/bluesky.api.test.ts
+++ b/test/bluesky.api.test.ts
@@ -2,6 +2,7 @@ import { afterEach, expect, test, vi } from 'vitest';
 import { app } from '../src/worker';
 import threadSingle from './fixtures/bluesky/thread-single.json';
 import threadMultiImage from './fixtures/bluesky/thread-multi-image.json';
+import threadGallery from './fixtures/bluesky/thread-gallery.json';
 import profileDetail from './fixtures/bluesky/profile-detail.json';
 import authorFeed from './fixtures/bluesky/author-feed.json';
 import getFollowers from './fixtures/bluesky/get-followers.json';
@@ -82,6 +83,41 @@ test('GET /2/status multi-image embed exposes photos', async () => {
   expect(res.status).toBe(200);
   const body = (await res.json()) as { status: { media: { photos?: { url: string }[] } } };
   expect(body.status.media.photos?.length).toBeGreaterThanOrEqual(2);
+});
+
+test('GET /2/status gallery embed exposes all carousel photos', async () => {
+  vi.spyOn(globalThis, 'fetch').mockImplementation(async (input: RequestInfo) => {
+    const u = typeof input === 'string' ? input : input.url;
+    if (u.includes('app.bsky.feed.getPostThread')) {
+      return new Response(JSON.stringify(threadGallery), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+    if (u.includes('app.bsky.actor.getProfiles')) {
+      return new Response(JSON.stringify({ profiles: [] }), { status: 200 });
+    }
+    if (u.includes('[REDACTED]')) {
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    }
+    throw new Error(`Unexpected fetch: ${u}`);
+  });
+
+  const res = await app.request('https://api.fxbsky.app/2/status/gallery.test/rkeygallery', {
+    headers: { 'User-Agent': 'FxEmbedTest/1.0' }
+  });
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as {
+    status: {
+      embed_card: string;
+      media: { photos?: { url: string; altText?: string }[]; all?: unknown[] };
+    };
+  };
+  expect(body.status.embed_card).toBe('summary_large_image');
+  expect(body.status.media.photos?.length).toBe(6);
+  expect(body.status.media.photos?.[0]?.url).toBe('https://cdn.bsky.app/gallery-full1');
+  expect(body.status.media.photos?.[5]?.altText).toBe('six');
+  expect(body.status.media.all?.length).toBe(6);
 });
 
 test('GET /2/search returns results and cursor.bottom', async () => {

--- a/test/fixtures/bluesky/thread-gallery.json
+++ b/test/fixtures/bluesky/thread-gallery.json
@@ -1,0 +1,91 @@
+{
+  "thread": {
+    "post": {
+      "uri": "at://did:plc:test222/app.bsky.feed.post/rkeygallery",
+      "cid": "bafycidgallery",
+      "author": {
+        "did": "did:plc:test222",
+        "handle": "gallery.test",
+        "displayName": "Gallery",
+        "avatar": "https://cdn.bsky.app/img/avatar.png",
+        "createdAt": "2023-01-01T00:00:00.000Z",
+        "associated": { "chat": { "allowIncoming": "all" } },
+        "labels": []
+      },
+      "record": {
+        "text": "Six image carousel",
+        "createdAt": "2026-06-13T12:00:00.000Z",
+        "langs": ["en"],
+        "facets": [],
+        "embed": {
+          "$type": "app.bsky.embed.gallery",
+          "items": [
+            {
+              "$type": "app.bsky.embed.gallery#image",
+              "alt": "one",
+              "aspectRatio": { "width": 1200, "height": 800 },
+              "image": {
+                "$type": "blob",
+                "ref": { "$link": "bafyimg1" },
+                "mimeType": "image/jpeg",
+                "size": 1000
+              }
+            }
+          ]
+        }
+      },
+      "embed": {
+        "$type": "app.bsky.embed.gallery#view",
+        "items": [
+          {
+            "$type": "app.bsky.embed.gallery#viewImage",
+            "thumbnail": "https://cdn.bsky.app/gallery-thumb1",
+            "fullsize": "https://cdn.bsky.app/gallery-full1",
+            "alt": "one",
+            "aspectRatio": { "width": 1200, "height": 800 }
+          },
+          {
+            "$type": "app.bsky.embed.gallery#viewImage",
+            "thumbnail": "https://cdn.bsky.app/gallery-thumb2",
+            "fullsize": "https://cdn.bsky.app/gallery-full2",
+            "alt": "two",
+            "aspectRatio": { "width": 800, "height": 600 }
+          },
+          {
+            "$type": "app.bsky.embed.gallery#viewImage",
+            "thumbnail": "https://cdn.bsky.app/gallery-thumb3",
+            "fullsize": "https://cdn.bsky.app/gallery-full3",
+            "alt": "three",
+            "aspectRatio": { "width": 900, "height": 900 }
+          },
+          {
+            "$type": "app.bsky.embed.gallery#viewImage",
+            "thumbnail": "https://cdn.bsky.app/gallery-thumb4",
+            "fullsize": "https://cdn.bsky.app/gallery-full4",
+            "alt": "four",
+            "aspectRatio": { "width": 1000, "height": 700 }
+          },
+          {
+            "$type": "app.bsky.embed.gallery#viewImage",
+            "thumbnail": "https://cdn.bsky.app/gallery-thumb5",
+            "fullsize": "https://cdn.bsky.app/gallery-full5",
+            "alt": "five",
+            "aspectRatio": { "width": 1100, "height": 750 }
+          },
+          {
+            "$type": "app.bsky.embed.gallery#viewImage",
+            "thumbnail": "https://cdn.bsky.app/gallery-thumb6",
+            "fullsize": "https://cdn.bsky.app/gallery-full6",
+            "alt": "six",
+            "aspectRatio": { "width": 1300, "height": 850 }
+          }
+        ]
+      },
+      "indexedAt": "2026-06-13T12:01:00.000Z",
+      "labels": [],
+      "likeCount": 0,
+      "repostCount": 0,
+      "replyCount": 0
+    }
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #2158 by adding support for Bluesky's new `app.bsky.embed.gallery#view` embed type.

Posts with more than four images now use a gallery embed whose hydrated view exposes images in an `items` array (`thumbnail` / `fullsize`) instead of the legacy `app.bsky.embed.images#view` `images` array (`thumb` / `fullsize`). We were only parsing the legacy shape, so carousel posts rendered with no images.

## Changes

- Add `gallery.ts` helper to detect gallery embeds and map `items` into API photos
- Route Bluesky embed image extraction through the shared helper in `processor.ts`
- Treat gallery embeds as visual media in Bluesky search (`feed=media`)
- Extend Bluesky vendor types for gallery view items
- Add fixture + API test for a six-image gallery post

## Behavior notes

- **Discord (native multi-image UA):** All gallery photos are exposed individually when mosaic is present, so Discord can show more than four images (first four in the grid, remainder as attachments).
- **Mosaic:** Still capped at four images in the composite URL; unchanged from existing multi-image behavior.
- **Legacy 1–4 image posts:** Continue using `app.bsky.embed.images#view` and are unaffected.

## Test plan

- [x] `npm run test -- test/bluesky.api.test.ts` (37 tests pass, including new gallery carousel test)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-acf8899b-1685-4354-ab6d-aab0e21c4b22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-acf8899b-1685-4354-ab6d-aab0e21c4b22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Bluesky gallery/carousel embeds, including multi-image photo extraction with accurate aspect ratios and alt text.

* **Bug Fixes**
  * Improved media parsing so gallery photos are derived consistently from embed data, including when primary embed images are missing.

* **Tests**
  * Added new gallery fixture and endpoint test to verify carousel photo count/order, URLs, and accessibility text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->