### PR TITLE
chore(renovate): enable automerge for 0.x minor and patch updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,6 @@
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch"],
-      "matchCurrentVersion": "!/^0/",
       "automerge": true,
       "automergeType": "pr",
       "platformAutomerge": true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

0.x dependency PRs (e.g. `@astrojs/starlight`, `@cloudflare/vitest-pool-workers`) were excluded from Renovate automerge by `matchCurrentVersion: "!/^0/"`, so they stayed open even after CI passed and the 7-day stability window elapsed.

This removes that exclusion so minor and patch updates for pre-1.0 packages follow the same automerge path as everything else.

## Unchanged behavior

- **`minimumReleaseAge: "7 days"`** — updates still wait 7 days before automerge is considered
- **`internalChecksFilter: "strict"`** — all required CI checks must pass
- **`matchUpdateTypes: ["minor", "patch"]`** — major updates are still manual
- **`platformAutomerge: true`** — still uses GitHub native automerge (rebase when behind `main`, then merge)

## After merge

Renovate will pick up the config on its next run. Open 0.x PRs like #2178 and #2171 should get automerge enabled on the next Renovate cycle (subject to passing checks, stability-days, and being up to date with `main`). #2171 will still need a conflict rebase first.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8dc9d75a-588a-4239-a9f5-0e7898da6dfd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8dc9d75a-588a-4239-a9f5-0e7898da6dfd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

