### PR TITLE
Fix SearchTimeline query metadata

### DIFF
--- a/packages/atmosphere/src/providers/twitter/graphql/queries.ts
+++ b/packages/atmosphere/src/providers/twitter/graphql/queries.ts
@@ -380,7 +380,7 @@ export const UserProfileAboutQuery: GraphQLQuery = {
 
 export const SearchTimelineQuery: GraphQLQuery = {
   httpMethod: 'GET',
-  queryId: 'GcXk9vN_d1jUfHNqLacXQA',
+  queryId: 'Bcw3RzK-PatNAmbnw54hFw',
   queryName: 'SearchTimeline',
   requiresAccount: true,
   variables: {


### PR DESCRIPTION
## Summary

Updates the X `SearchTimeline` persisted query ID to match the current x.com web bundle.

This fixes `GET /2/search` returning empty 404 responses while typeahead and other routes still work.

## Testing

- `npm run build:atmosphere`
- `npm run test -- test/api.search.test.ts test/searchTimelineErrors.test.ts`
- `npm run build-local`
- Local smoke test with account proxy: `/2/search?q=neo&count=5`, `feed=latest`, `feed=top`, `feed=media`, and `q=from:jack` all returned 200 with results
- Local smoke test for `/2/trends?count=5` and `/2/trends?type=trending&count=5` returned 200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the search timeline request configuration to use a new identifier, which may improve query reliability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->